### PR TITLE
feat: Add provisional email support for HODs, Founders, and Admins

### DIFF
--- a/src/app/(dashboard)/dashboard/admin/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/admin/settings/page.tsx
@@ -1,0 +1,239 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { logger } from "@/core/infra/logging/logger";
+import { ROUTES } from "@/core/config/route-registry";
+import { isAdmin } from "@/modules/admin/server/is-admin";
+import { ManageMasterDataService } from "@/core/domain/admin/ManageMasterDataService";
+import { ManageActorsService } from "@/core/domain/admin/ManageActorsService";
+import { ManageAdminsService } from "@/core/domain/admin/ManageAdminsService";
+import { SupabaseAdminRepository } from "@/modules/admin/repositories/SupabaseAdminRepository";
+import { MasterDataTable } from "@/modules/admin/ui/settings/master-data-table";
+import { DepartmentsManagement } from "@/modules/admin/ui/settings/departments-management";
+import { FinanceApproversManagement } from "@/modules/admin/ui/settings/finance-approvers-management";
+import { UsersManagement } from "@/modules/admin/ui/settings/users-management";
+import { AdminsManagement } from "@/modules/admin/ui/settings/admins-management";
+import { BackButton } from "@/components/ui/back-button";
+import { ThemeToggle } from "@/components/theme-toggle";
+import type { MasterDataTableName } from "@/core/domain/admin/contracts";
+
+export const metadata = {
+  title: "System Settings | NxtClaim",
+};
+
+type SearchParamsValue = string | string[] | undefined;
+
+function firstParam(value: SearchParamsValue): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+type SidebarGroup = {
+  groupLabel: string;
+  items: { key: string; label: string }[];
+};
+
+const SIDEBAR_GROUPS: SidebarGroup[] = [
+  {
+    groupLabel: "Master Data",
+    items: [
+      { key: "categories", label: "Expense Categories" },
+      { key: "products", label: "Products" },
+      { key: "locations", label: "Locations" },
+      { key: "payment-modes", label: "Payment Modes" },
+    ],
+  },
+  {
+    groupLabel: "Routing",
+    items: [
+      { key: "departments", label: "Departments & Actors" },
+      { key: "finance", label: "Finance Approvers" },
+    ],
+  },
+  {
+    groupLabel: "Access",
+    items: [
+      { key: "users", label: "Users" },
+      { key: "admins", label: "Administrators" },
+    ],
+  },
+];
+
+const ALL_KEYS = SIDEBAR_GROUPS.flatMap((g) => g.items.map((i) => i.key));
+type TabKey = string;
+
+const MASTER_DATA_MAP: Record<string, { tableName: MasterDataTableName; displayName: string }> = {
+  categories: { tableName: "master_expense_categories", displayName: "Expense Categories" },
+  products: { tableName: "master_products", displayName: "Products" },
+  locations: { tableName: "master_locations", displayName: "Locations" },
+  "payment-modes": { tableName: "master_payment_modes", displayName: "Payment Modes" },
+};
+
+const PAGE_SIZE = 20;
+
+export default async function AdminSettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, SearchParamsValue>>;
+}) {
+  const adminCheck = await isAdmin();
+  if (!adminCheck) {
+    notFound();
+  }
+
+  const resolvedParams = await searchParams;
+  const rawTab = firstParam(resolvedParams?.tab);
+  const activeTab: TabKey = ALL_KEYS.includes(rawTab ?? "") ? (rawTab as TabKey) : "categories";
+
+  const adminRepository = new SupabaseAdminRepository();
+  const masterDataService = new ManageMasterDataService({ repository: adminRepository, logger });
+  const actorsService = new ManageActorsService({ repository: adminRepository, logger });
+  const adminsService = new ManageAdminsService({ repository: adminRepository, logger });
+
+  const cursor = firstParam(resolvedParams?.cursor) ?? null;
+  const previousCursor = firstParam(resolvedParams?.prevCursor) ?? null;
+
+  const isMasterDataTab = activeTab in MASTER_DATA_MAP;
+  const masterMeta = MASTER_DATA_MAP[activeTab];
+
+  const [masterDataResult, departmentsResult, financeResult, usersResult, adminsResult] =
+    await Promise.all([
+      isMasterDataTab
+        ? masterDataService.getItems({ tableName: masterMeta.tableName })
+        : Promise.resolve(null),
+      activeTab === "departments"
+        ? actorsService.getDepartmentsWithActors()
+        : Promise.resolve(null),
+      activeTab === "finance" ? actorsService.getFinanceApprovers() : Promise.resolve(null),
+      activeTab === "users"
+        ? adminsService.getAllUsers({ cursor, limit: PAGE_SIZE })
+        : Promise.resolve(null),
+      activeTab === "admins" ? adminsService.getAdmins() : Promise.resolve(null),
+    ]);
+
+  const allUsersResult =
+    activeTab === "finance" ? await adminsService.getAllUsers({ cursor: null, limit: 500 }) : null;
+
+  const allUsers = allUsersResult?.data?.data ?? [];
+
+  function tabHref(key: string) {
+    return `${ROUTES.admin.settings}?tab=${key}`;
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 px-4 py-8 dark:bg-[#0B0F1A] sm:px-6">
+      <main className="mx-auto max-w-6xl space-y-6">
+        {/* Top bar */}
+        <div className="flex items-center justify-between">
+          <BackButton fallbackHref={ROUTES.claims.myClaims} className="w-fit" />
+          <ThemeToggle />
+        </div>
+
+        {/* Page header */}
+        <div>
+          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">System Settings</h1>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Manage master data, departments, and system roles.
+          </p>
+        </div>
+
+        {/* Sidebar + content layout */}
+        <div className="flex flex-col gap-6 md:flex-row md:gap-8">
+          {/* Left sidebar */}
+          <aside className="w-full flex-shrink-0 md:w-56">
+            <nav className="space-y-5" aria-label="Settings navigation">
+              {SIDEBAR_GROUPS.map((group) => (
+                <div key={group.groupLabel}>
+                  <p className="mb-1.5 px-2 text-[11px] font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
+                    {group.groupLabel}
+                  </p>
+                  <ul className="space-y-0.5">
+                    {group.items.map((item) => {
+                      const isActive = activeTab === item.key;
+                      return (
+                        <li key={item.key}>
+                          <Link
+                            href={tabHref(item.key)}
+                            className={`flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 ${
+                              isActive
+                                ? "bg-indigo-600 text-white shadow-sm"
+                                : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                            }`}
+                          >
+                            {item.label}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </nav>
+          </aside>
+
+          {/* Right content */}
+          <div className="min-w-0 flex-1">
+            <div className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+              {isMasterDataTab && masterDataResult ? (
+                masterDataResult.errorMessage ? (
+                  <ErrorBox message={masterDataResult.errorMessage} />
+                ) : (
+                  <MasterDataTable
+                    tableName={masterMeta.tableName}
+                    displayName={masterMeta.displayName}
+                    items={masterDataResult.data}
+                  />
+                )
+              ) : null}
+
+              {activeTab === "departments" && departmentsResult ? (
+                departmentsResult.errorMessage ? (
+                  <ErrorBox message={departmentsResult.errorMessage} />
+                ) : (
+                  <DepartmentsManagement departments={departmentsResult.data} />
+                )
+              ) : null}
+
+              {activeTab === "finance" && financeResult ? (
+                financeResult.errorMessage ? (
+                  <ErrorBox message={financeResult.errorMessage} />
+                ) : (
+                  <FinanceApproversManagement approvers={financeResult.data} />
+                )
+              ) : null}
+
+              {activeTab === "users" && usersResult ? (
+                usersResult.errorMessage || !usersResult.data ? (
+                  <ErrorBox message={usersResult.errorMessage ?? "Failed to load users."} />
+                ) : (
+                  <UsersManagement
+                    users={usersResult.data.data}
+                    hasNextPage={usersResult.data.hasNextPage}
+                    nextCursor={usersResult.data.nextCursor}
+                    hasPreviousPage={Boolean(previousCursor ?? cursor)}
+                    previousCursor={previousCursor ?? (cursor ? "__first__" : null)}
+                  />
+                )
+              ) : null}
+
+              {activeTab === "admins" && adminsResult ? (
+                adminsResult.errorMessage ? (
+                  <ErrorBox message={adminsResult.errorMessage} />
+                ) : (
+                  <AdminsManagement admins={adminsResult.data} />
+                )
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ErrorBox({ message }: { message: string }) {
+  return (
+    <p className="rounded-xl bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:bg-rose-950/40 dark:text-rose-200">
+      {message}
+    </p>
+  );
+}

--- a/src/app/(dashboard)/dashboard/claims/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/claims/[id]/page.tsx
@@ -26,6 +26,8 @@ import {
   getAvailableClaimActions,
   type ClaimActionRole,
 } from "@/modules/claims/utils/get-available-claim-actions";
+import { isAdmin } from "@/modules/admin/server/is-admin";
+import { AdminSoftDeletePanel } from "@/modules/admin/ui/admin-soft-delete-panel";
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -436,9 +438,10 @@ async function ClaimDetailCore({ params }: { params: Promise<{ id: string }> }) 
   const authRepository = new SupabaseServerAuthRepository();
   const claimRepository = new SupabaseClaimRepository();
 
-  const [currentUserResult, claimResult] = await Promise.all([
+  const [currentUserResult, claimResult, isAdminUser] = await Promise.all([
     authRepository.getCurrentUser(),
     claimRepository.getClaimDetailById(claimId),
+    isAdmin(),
   ]);
 
   if (currentUserResult.errorMessage || !currentUserResult.user?.id) {
@@ -502,7 +505,7 @@ async function ClaimDetailCore({ params }: { params: Promise<{ id: string }> }) 
     canViewAsFinance;
   const canEditByFinance = isFinanceActor;
 
-  if (!canView) {
+  if (!canView && !isAdminUser) {
     notFound();
   }
 
@@ -569,6 +572,7 @@ async function ClaimDetailCore({ params }: { params: Promise<{ id: string }> }) 
 
   return (
     <>
+      {isAdminUser ? <AdminSoftDeletePanel claimId={claim.id} /> : null}
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-800 dark:bg-slate-900">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>

--- a/src/app/(dashboard)/dashboard/my-claims/page.tsx
+++ b/src/app/(dashboard)/dashboard/my-claims/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Suspense, use } from "react";
+import { Suspense } from "react";
 import { BackButton } from "@/components/ui/back-button";
 import { TableSkeleton } from "@/components/ui/table-skeleton";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -26,6 +26,8 @@ import {
   rejectFinanceAction,
 } from "@/modules/claims/actions";
 import { SupabaseClaimRepository } from "@/modules/claims/repositories/SupabaseClaimRepository";
+import { isAdmin } from "@/modules/admin/server/is-admin";
+import { AdminClaimsSection } from "@/modules/admin/ui/admin-claims-section";
 import { ClaimDecisionActionForm } from "@/modules/claims/ui/claim-decision-action-form";
 import { ClaimRejectWithReasonForm } from "@/modules/claims/ui/claim-reject-with-reason-form";
 import { ClaimStatusBadge } from "@/modules/claims/ui/claim-status-badge";
@@ -37,7 +39,7 @@ import { ClaimSemanticDownloadButton } from "@/modules/claims/ui/claim-semantic-
 
 const PAGE_SIZE = 10;
 type SearchParamsValue = string | string[] | undefined;
-type ViewMode = "submissions" | "approvals";
+type ViewMode = "submissions" | "approvals" | "admin";
 
 export const metadata = {
   title: "My Claims | NxtClaim",
@@ -67,13 +69,17 @@ function toSearchParams(searchParams?: Record<string, SearchParamsValue>): URLSe
   return params;
 }
 
-function resolveView(value: string | undefined, canViewApprovals: boolean): ViewMode {
-  if (value === "approvals" && canViewApprovals) {
-    return "approvals";
+function resolveView(
+  value: string | undefined,
+  canViewApprovals: boolean,
+  isAdminUser: boolean,
+): ViewMode {
+  if (value === "admin" && isAdminUser) {
+    return "admin";
   }
 
-  if (value === "submissions") {
-    return "submissions";
+  if (value === "approvals" && canViewApprovals) {
+    return "approvals";
   }
 
   return "submissions";
@@ -187,11 +193,7 @@ function buildViewHref(
   params.delete("cursor");
   params.delete("prevCursor");
 
-  if (targetView === "approvals") {
-    params.set("view", "approvals");
-  } else {
-    params.set("view", "submissions");
-  }
+  params.set("view", targetView);
 
   const query = params.toString();
   return query ? `${ROUTES.claims.myClaims}?${query}` : ROUTES.claims.myClaims;
@@ -969,7 +971,7 @@ async function FilterBarWithData({
   exportScope,
   defaultFiltersExpanded,
 }: {
-  exportScope: ViewMode;
+  exportScope: "submissions" | "approvals";
   defaultFiltersExpanded: boolean;
 }) {
   const claimRepository = new SupabaseClaimRepository();
@@ -1012,8 +1014,10 @@ async function FilterBarWithData({
 
 async function MyClaimsDashboardPageContent({
   searchParams,
+  isAdminUser,
 }: {
   searchParams: Record<string, SearchParamsValue>;
+  isAdminUser: boolean;
 }) {
   const authRepository = new SupabaseServerAuthRepository();
   const claimRepository = new SupabaseClaimRepository();
@@ -1038,17 +1042,21 @@ async function MyClaimsDashboardPageContent({
   const canViewApprovals = viewerContextResult.canViewApprovals;
   const requestedView = firstParamValue(resolvedSearchParams?.view);
 
-  if (canViewApprovals && !requestedView) {
+  if (canViewApprovals && !requestedView && !isAdminUser) {
     redirect(buildViewHref(resolvedSearchParams, "approvals"));
   }
 
-  const activeView = resolveView(requestedView, canViewApprovals);
+  const activeView = resolveView(requestedView, canViewApprovals, isAdminUser);
+
+  if (activeView === "admin") {
+    return <AdminClaimsSection searchParams={resolvedSearchParams} />;
+  }
 
   return (
     <>
       <Suspense fallback={<FilterBarSkeleton />}>
         <FilterBarWithData
-          exportScope={activeView}
+          exportScope={activeView as "submissions" | "approvals"}
           defaultFiltersExpanded={viewerContextResult.activeScope === "finance"}
         />
       </Suspense>
@@ -1072,16 +1080,24 @@ async function MyClaimsDashboardPageContent({
   );
 }
 
-export default function MyClaimsDashboardPage({
+export default async function MyClaimsDashboardPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, SearchParamsValue>>;
 }) {
-  const resolvedSearchParams = use(searchParams);
+  const [resolvedSearchParams, isAdminUser] = await Promise.all([searchParams, isAdmin()]);
+
   const requestedView = firstParamValue(resolvedSearchParams?.view);
-  const activeView: ViewMode = requestedView === "approvals" ? "approvals" : "submissions";
+  const activeView: ViewMode =
+    requestedView === "admin" && isAdminUser
+      ? "admin"
+      : requestedView === "approvals"
+        ? "approvals"
+        : "submissions";
+
   const submissionsHref = buildViewHref(resolvedSearchParams, "submissions");
   const approvalsHref = buildViewHref(resolvedSearchParams, "approvals");
+  const adminHref = buildViewHref(resolvedSearchParams, "admin");
 
   return (
     <div className="min-h-screen bg-zinc-50 px-6 py-8 dark:bg-[#0B0F1A]">
@@ -1097,6 +1113,14 @@ export default function MyClaimsDashboardPage({
             </div>
             <div className="flex items-center gap-2">
               <ThemeToggle />
+              {isAdminUser ? (
+                <Link
+                  href={ROUTES.admin.settings}
+                  className="inline-flex items-center rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition-all duration-200 hover:bg-zinc-50 active:scale-[0.98] dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                >
+                  System Settings
+                </Link>
+              ) : null}
               <Link
                 href={ROUTES.claims.new}
                 className="inline-flex items-center rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-all duration-200 hover:bg-indigo-500 active:scale-[0.98]"
@@ -1127,11 +1151,26 @@ export default function MyClaimsDashboardPage({
             >
               Approvals History
             </Link>
+            {isAdminUser ? (
+              <Link
+                href={adminHref}
+                className={`rounded-lg px-3 py-1.5 text-sm font-semibold transition-all duration-200 active:scale-[0.98] ${
+                  activeView === "admin"
+                    ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                    : "text-zinc-700 hover:bg-zinc-200/70 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                }`}
+              >
+                Admin Overview
+              </Link>
+            ) : null}
           </div>
         </section>
 
         <Suspense fallback={<MyClaimsShellSkeleton />}>
-          <MyClaimsDashboardPageContent searchParams={resolvedSearchParams} />
+          <MyClaimsDashboardPageContent
+            searchParams={resolvedSearchParams}
+            isAdminUser={isAdminUser}
+          />
         </Suspense>
       </main>
     </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,9 @@ import { GetWalletSummaryService } from "@/core/domain/dashboard/GetWalletSummar
 import { SupabaseServerAuthRepository } from "@/modules/auth/repositories/supabase-server-auth.repository";
 import { SupabaseDashboardRepository } from "@/modules/dashboard/repositories/SupabaseDashboardRepository";
 import { WalletSummary } from "@/modules/dashboard/ui/wallet-summary";
+import { isAdmin } from "@/modules/admin/server/is-admin";
+
+export const dynamic = "force-dynamic";
 
 const authRepository = new SupabaseServerAuthRepository();
 const dashboardRepository = new SupabaseDashboardRepository();
@@ -23,7 +26,10 @@ async function logoutDashboardAction(): Promise<void> {
 }
 
 export default async function DashboardPage() {
-  const currentUserResult = await authRepository.getCurrentUser();
+  const [currentUserResult, isAdminUser] = await Promise.all([
+    authRepository.getCurrentUser(),
+    isAdmin(),
+  ]);
   if (currentUserResult.errorMessage || !currentUserResult.user?.id) {
     redirect(ROUTES.login);
   }
@@ -84,6 +90,15 @@ export default async function DashboardPage() {
           >
             My Claims
           </Link>
+
+          {isAdminUser ? (
+            <Link
+              href={ROUTES.admin.settings}
+              className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-2 text-sm font-semibold text-zinc-700 transition-all duration-200 hover:bg-zinc-100 active:scale-[0.98] dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+            >
+              System Settings
+            </Link>
+          ) : null}
         </div>
       </main>
     </div>

--- a/src/core/config/route-registry.ts
+++ b/src/core/config/route-registry.ts
@@ -23,4 +23,7 @@ export const ROUTES = {
   exportApi: {
     claims: "/api/export/claims",
   },
+  admin: {
+    settings: "/dashboard/admin/settings",
+  },
 } as const;

--- a/src/core/domain/admin/AdminSoftDeleteClaimService.ts
+++ b/src/core/domain/admin/AdminSoftDeleteClaimService.ts
@@ -1,0 +1,83 @@
+import type { AdminDomainLogger, AdminRepository } from "@/core/domain/admin/contracts";
+
+type Dependencies = {
+  repository: AdminRepository;
+  logger: AdminDomainLogger;
+};
+
+type AdminSoftDeleteInput = {
+  claimId: string;
+  actorId: string;
+};
+
+type AdminSoftDeleteResult = {
+  success: boolean;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export class AdminSoftDeleteClaimService {
+  private readonly repository: AdminRepository;
+  private readonly logger: AdminDomainLogger;
+
+  constructor({ repository, logger }: Dependencies) {
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  async execute(input: AdminSoftDeleteInput): Promise<AdminSoftDeleteResult> {
+    if (!input.claimId || !input.claimId.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Claim ID is required.",
+      };
+    }
+
+    if (!input.actorId || !input.actorId.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Actor ID is required.",
+      };
+    }
+
+    this.logger.info("AdminSoftDeleteClaimService.execute", {
+      claimId: input.claimId,
+      actorId: input.actorId,
+    });
+
+    const result = await this.repository.softDeleteClaim(input.claimId, input.actorId);
+
+    if (!result.success) {
+      this.logger.error("AdminSoftDeleteClaimService.execute.failed", {
+        claimId: input.claimId,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        success: false,
+        errorCode: "SOFT_DELETE_FAILED",
+        errorMessage: result.errorMessage ?? "Failed to soft-delete claim.",
+      };
+    }
+
+    if (result.errorMessage) {
+      // Audit log warning: soft-delete succeeded but log write failed
+      this.logger.warn("AdminSoftDeleteClaimService.execute.auditLogWarning", {
+        claimId: input.claimId,
+        warningMessage: result.errorMessage,
+      });
+    }
+
+    this.logger.info("AdminSoftDeleteClaimService.execute.success", {
+      claimId: input.claimId,
+    });
+
+    return {
+      success: true,
+      errorCode: null,
+      errorMessage: null,
+    };
+  }
+}

--- a/src/core/domain/admin/GetAdminClaimsService.ts
+++ b/src/core/domain/admin/GetAdminClaimsService.ts
@@ -1,0 +1,62 @@
+import type {
+  AdminClaimRecord,
+  AdminClaimsFilters,
+  AdminCursorPaginatedResult,
+  AdminCursorPaginationInput,
+  AdminDomainLogger,
+  AdminRepository,
+} from "@/core/domain/admin/contracts";
+
+type Dependencies = {
+  repository: AdminRepository;
+  logger: AdminDomainLogger;
+};
+
+type GetAdminClaimsInput = {
+  filters: AdminClaimsFilters;
+  pagination: AdminCursorPaginationInput;
+};
+
+type GetAdminClaimsResult = {
+  data: AdminCursorPaginatedResult<AdminClaimRecord> | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export class GetAdminClaimsService {
+  private readonly repository: AdminRepository;
+  private readonly logger: AdminDomainLogger;
+
+  constructor({ repository, logger }: Dependencies) {
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  async execute(input: GetAdminClaimsInput): Promise<GetAdminClaimsResult> {
+    this.logger.info("GetAdminClaimsService.execute", {
+      filters: input.filters,
+      cursor: input.pagination.cursor,
+      limit: input.pagination.limit,
+    });
+
+    const result = await this.repository.getAllClaims(input.filters, input.pagination);
+
+    if (result.errorMessage) {
+      this.logger.error("GetAdminClaimsService.execute.repositoryError", {
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        data: null,
+        errorCode: "FETCH_FAILED",
+        errorMessage: result.errorMessage,
+      };
+    }
+
+    return {
+      data: result.data,
+      errorCode: null,
+      errorMessage: null,
+    };
+  }
+}

--- a/src/core/domain/admin/ManageActorsService.ts
+++ b/src/core/domain/admin/ManageActorsService.ts
@@ -1,0 +1,309 @@
+import type {
+  AdminDomainLogger,
+  AdminRepository,
+  DepartmentWithActors,
+  FinanceApproverRecord,
+} from "@/core/domain/admin/contracts";
+
+type Dependencies = {
+  repository: AdminRepository;
+  logger: AdminDomainLogger;
+};
+
+type UpdateDepartmentActorsInput = {
+  departmentId: string;
+  hodUserId: string;
+  founderUserId: string;
+};
+
+type UpdateDepartmentActorsByEmailInput = {
+  departmentId: string;
+  hodEmail: string;
+  founderEmail: string;
+};
+
+type CreateFinanceApproverInput = { userId: string };
+type AddFinanceApproverByEmailInput = { email: string };
+
+type UpdateFinanceApproverInput = {
+  id: string;
+  payload: { isActive?: boolean; isPrimary?: boolean };
+};
+
+type GetDepartmentsResult = {
+  data: DepartmentWithActors[];
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type GetFinanceApproversResult = {
+  data: FinanceApproverRecord[];
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type MutateResult = {
+  success: boolean;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type FinanceApproverResult = {
+  data: FinanceApproverRecord | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export class ManageActorsService {
+  private readonly repository: AdminRepository;
+  private readonly logger: AdminDomainLogger;
+
+  constructor({ repository, logger }: Dependencies) {
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  async getDepartmentsWithActors(): Promise<GetDepartmentsResult> {
+    const result = await this.repository.getDepartmentsWithActors();
+
+    if (result.errorMessage) {
+      this.logger.error("ManageActorsService.getDepartmentsWithActors.failed", {
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: [], errorCode: "FETCH_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async updateDepartmentActors(input: UpdateDepartmentActorsInput): Promise<MutateResult> {
+    if (!input.departmentId?.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Department ID is required.",
+      };
+    }
+
+    if (!input.hodUserId?.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "HOD user ID is required.",
+      };
+    }
+
+    if (!input.founderUserId?.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Founder user ID is required.",
+      };
+    }
+
+    if (input.hodUserId === input.founderUserId) {
+      return {
+        success: false,
+        errorCode: "SAME_APPROVER",
+        errorMessage: "HOD and Founder cannot be the same person.",
+      };
+    }
+
+    this.logger.info("ManageActorsService.updateDepartmentActors", {
+      departmentId: input.departmentId,
+      hodUserId: input.hodUserId,
+      founderUserId: input.founderUserId,
+    });
+
+    const result = await this.repository.updateDepartmentActors(
+      input.departmentId,
+      input.hodUserId,
+      input.founderUserId,
+    );
+
+    if (!result.success) {
+      this.logger.error("ManageActorsService.updateDepartmentActors.failed", {
+        departmentId: input.departmentId,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        success: false,
+        errorCode: "UPDATE_FAILED",
+        errorMessage: result.errorMessage ?? "Failed to update department actors.",
+      };
+    }
+
+    return { success: true, errorCode: null, errorMessage: null };
+  }
+
+  async updateDepartmentActorsByEmail(
+    input: UpdateDepartmentActorsByEmailInput,
+  ): Promise<MutateResult> {
+    const hodEmail = input.hodEmail?.trim().toLowerCase();
+    const founderEmail = input.founderEmail?.trim().toLowerCase();
+
+    if (!hodEmail || !hodEmail.includes("@")) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "A valid HOD email address is required.",
+      };
+    }
+
+    if (!founderEmail || !founderEmail.includes("@")) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "A valid Founder email address is required.",
+      };
+    }
+
+    if (hodEmail === founderEmail) {
+      return {
+        success: false,
+        errorCode: "SAME_APPROVER",
+        errorMessage: "HOD and Founder cannot be the same person.",
+      };
+    }
+
+    if (!input.departmentId?.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Department ID is required.",
+      };
+    }
+
+    this.logger.info("ManageActorsService.updateDepartmentActorsByEmail", {
+      departmentId: input.departmentId,
+      hodEmail,
+      founderEmail,
+    });
+
+    const result = await this.repository.updateDepartmentActorsByEmail(
+      input.departmentId,
+      hodEmail,
+      founderEmail,
+    );
+
+    if (!result.success) {
+      this.logger.error("ManageActorsService.updateDepartmentActorsByEmail.failed", {
+        departmentId: input.departmentId,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        success: false,
+        errorCode: "UPDATE_FAILED",
+        errorMessage: result.errorMessage ?? "Failed to update department actors.",
+      };
+    }
+
+    return { success: true, errorCode: null, errorMessage: null };
+  }
+
+  async getFinanceApprovers(): Promise<GetFinanceApproversResult> {
+    const result = await this.repository.getFinanceApprovers();
+
+    if (result.errorMessage) {
+      this.logger.error("ManageActorsService.getFinanceApprovers.failed", {
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: [], errorCode: "FETCH_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async createFinanceApprover(input: CreateFinanceApproverInput): Promise<FinanceApproverResult> {
+    if (!input.userId?.trim()) {
+      return { data: null, errorCode: "INVALID_INPUT", errorMessage: "User ID is required." };
+    }
+
+    this.logger.info("ManageActorsService.createFinanceApprover", { userId: input.userId });
+
+    const result = await this.repository.createFinanceApprover(input.userId);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageActorsService.createFinanceApprover.failed", {
+        userId: input.userId,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        data: null,
+        errorCode: "CREATE_FAILED",
+        errorMessage: result.errorMessage,
+      };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async addFinanceApproverByEmail(
+    input: AddFinanceApproverByEmailInput,
+  ): Promise<FinanceApproverResult> {
+    const trimmedEmail = input.email?.trim().toLowerCase();
+    if (!trimmedEmail || !trimmedEmail.includes("@")) {
+      return {
+        data: null,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "A valid email address is required.",
+      };
+    }
+
+    this.logger.info("ManageActorsService.addFinanceApproverByEmail", { email: trimmedEmail });
+
+    const result = await this.repository.addFinanceApproverByEmail(trimmedEmail);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageActorsService.addFinanceApproverByEmail.failed", {
+        email: trimmedEmail,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        data: null,
+        errorCode: "CREATE_FAILED",
+        errorMessage: result.errorMessage,
+      };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async updateFinanceApprover(input: UpdateFinanceApproverInput): Promise<FinanceApproverResult> {
+    if (!input.id?.trim()) {
+      return {
+        data: null,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Finance approver ID is required.",
+      };
+    }
+
+    this.logger.info("ManageActorsService.updateFinanceApprover", {
+      id: input.id,
+      payload: input.payload,
+    });
+
+    const result = await this.repository.updateFinanceApprover(input.id, input.payload);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageActorsService.updateFinanceApprover.failed", {
+        id: input.id,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        data: null,
+        errorCode: "UPDATE_FAILED",
+        errorMessage: result.errorMessage,
+      };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+}

--- a/src/core/domain/admin/ManageAdminsService.ts
+++ b/src/core/domain/admin/ManageAdminsService.ts
@@ -1,0 +1,129 @@
+import type {
+  AdminCursorPaginatedResult,
+  AdminCursorPaginationInput,
+  AdminDomainLogger,
+  AdminRecord,
+  AdminRepository,
+  AdminUserRecord,
+} from "@/core/domain/admin/contracts";
+
+type Dependencies = {
+  repository: AdminRepository;
+  logger: AdminDomainLogger;
+};
+
+type GetUsersResult = {
+  data: AdminCursorPaginatedResult<AdminUserRecord> | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type GetAdminsResult = {
+  data: AdminRecord[];
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type AddAdminResult = {
+  data: AdminRecord | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type RemoveAdminResult = {
+  success: boolean;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export class ManageAdminsService {
+  private readonly repository: AdminRepository;
+  private readonly logger: AdminDomainLogger;
+
+  constructor({ repository, logger }: Dependencies) {
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  async getAllUsers(pagination: AdminCursorPaginationInput): Promise<GetUsersResult> {
+    const result = await this.repository.getAllUsers(pagination);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageAdminsService.getAllUsers.failed", {
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: null, errorCode: "FETCH_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async getAdmins(): Promise<GetAdminsResult> {
+    const result = await this.repository.getAdmins();
+
+    if (result.errorMessage) {
+      this.logger.error("ManageAdminsService.getAdmins.failed", {
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: [], errorCode: "FETCH_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async addAdminByEmail(email: string): Promise<AddAdminResult> {
+    if (!email?.trim()) {
+      return { data: null, errorCode: "INVALID_INPUT", errorMessage: "Email is required." };
+    }
+
+    this.logger.info("ManageAdminsService.addAdminByEmail", { email });
+
+    const result = await this.repository.addAdminByEmail(email);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageAdminsService.addAdminByEmail.failed", {
+        email,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        data: null,
+        errorCode: "ADD_FAILED",
+        errorMessage: result.errorMessage,
+      };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async removeAdmin(adminId: string): Promise<RemoveAdminResult> {
+    if (!adminId?.trim()) {
+      return {
+        success: false,
+        errorCode: "INVALID_INPUT",
+        errorMessage: "Admin record ID is required.",
+      };
+    }
+
+    this.logger.info("ManageAdminsService.removeAdmin", { adminId });
+
+    const result = await this.repository.removeAdmin(adminId);
+
+    if (!result.success) {
+      this.logger.error("ManageAdminsService.removeAdmin.failed", {
+        adminId,
+        errorMessage: result.errorMessage,
+      });
+
+      return {
+        success: false,
+        errorCode: "REMOVE_FAILED",
+        errorMessage: result.errorMessage ?? "Failed to remove admin.",
+      };
+    }
+
+    return { success: true, errorCode: null, errorMessage: null };
+  }
+}

--- a/src/core/domain/admin/ManageMasterDataService.ts
+++ b/src/core/domain/admin/ManageMasterDataService.ts
@@ -1,0 +1,118 @@
+import type {
+  AdminDomainLogger,
+  AdminRepository,
+  MasterDataItem,
+  MasterDataTableName,
+} from "@/core/domain/admin/contracts";
+
+type Dependencies = {
+  repository: AdminRepository;
+  logger: AdminDomainLogger;
+};
+
+type GetItemsInput = { tableName: MasterDataTableName };
+
+type CreateItemInput = { tableName: MasterDataTableName; name: string };
+
+type UpdateItemInput = {
+  tableName: MasterDataTableName;
+  id: string;
+  payload: { name?: string; isActive?: boolean };
+};
+
+type GetItemsResult = {
+  data: MasterDataItem[];
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+type MutateItemResult = {
+  data: MasterDataItem | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export class ManageMasterDataService {
+  private readonly repository: AdminRepository;
+  private readonly logger: AdminDomainLogger;
+
+  constructor({ repository, logger }: Dependencies) {
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  async getItems(input: GetItemsInput): Promise<GetItemsResult> {
+    const result = await this.repository.getMasterDataItems(input.tableName);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageMasterDataService.getItems.failed", {
+        tableName: input.tableName,
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: [], errorCode: "FETCH_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async createItem(input: CreateItemInput): Promise<MutateItemResult> {
+    const name = input.name.trim();
+
+    if (!name) {
+      return { data: null, errorCode: "INVALID_INPUT", errorMessage: "Name is required." };
+    }
+
+    this.logger.info("ManageMasterDataService.createItem", {
+      tableName: input.tableName,
+      name,
+    });
+
+    const result = await this.repository.createMasterDataItem(input.tableName, name);
+
+    if (result.errorMessage) {
+      this.logger.error("ManageMasterDataService.createItem.failed", {
+        tableName: input.tableName,
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: null, errorCode: "CREATE_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+
+  async updateItem(input: UpdateItemInput): Promise<MutateItemResult> {
+    if (!input.id?.trim()) {
+      return { data: null, errorCode: "INVALID_INPUT", errorMessage: "Item ID is required." };
+    }
+
+    if (input.payload.name !== undefined && !input.payload.name.trim()) {
+      return { data: null, errorCode: "INVALID_INPUT", errorMessage: "Name cannot be empty." };
+    }
+
+    this.logger.info("ManageMasterDataService.updateItem", {
+      tableName: input.tableName,
+      id: input.id,
+      payload: input.payload,
+    });
+
+    const result = await this.repository.updateMasterDataItem(
+      input.tableName,
+      input.id,
+      input.payload,
+    );
+
+    if (result.errorMessage) {
+      this.logger.error("ManageMasterDataService.updateItem.failed", {
+        tableName: input.tableName,
+        id: input.id,
+        errorMessage: result.errorMessage,
+      });
+
+      return { data: null, errorCode: "UPDATE_FAILED", errorMessage: result.errorMessage };
+    }
+
+    return { data: result.data, errorCode: null, errorMessage: null };
+  }
+}

--- a/src/core/domain/admin/contracts.ts
+++ b/src/core/domain/admin/contracts.ts
@@ -1,0 +1,203 @@
+import type { DbClaimStatus } from "@/core/constants/statuses";
+
+// ----------------------------------------------------------------
+// Shared value types
+// ----------------------------------------------------------------
+
+export type MasterDataTableName =
+  | "master_expense_categories"
+  | "master_products"
+  | "master_locations"
+  | "master_payment_modes";
+
+export type MasterDataItem = {
+  id: string;
+  name: string;
+  isActive: boolean;
+};
+
+export type AdminClaimRecord = {
+  claimId: string;
+  employeeName: string;
+  employeeId: string;
+  departmentName: string;
+  typeOfClaim: string;
+  amount: number;
+  status: DbClaimStatus;
+  submittedOn: string;
+  hodActionDate: string | null;
+  financeActionDate: string | null;
+  detailType: "expense" | "advance";
+  submissionType: "Self" | "On Behalf";
+  isActive: boolean;
+  departmentId: string | null;
+};
+
+export type AdminUserRecord = {
+  id: string;
+  email: string;
+  fullName: string | null;
+  role: string;
+  isActive: boolean;
+  createdAt: string;
+};
+
+export type AdminRecord = {
+  id: string;
+  /** Null for provisional entries where the user has not yet signed in. */
+  userId: string | null;
+  email: string;
+  fullName: string | null;
+  createdAt: string;
+  /** Set when admin was added by email before their first login. Null once promoted. */
+  provisionalEmail: string | null;
+};
+
+export type DepartmentWithActors = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  hodUserId: string | null;
+  hodUserName: string | null;
+  hodUserEmail: string | null;
+  /** Set when HOD was entered by email before their first login. Null once promoted. */
+  hodProvisionalEmail: string | null;
+  founderUserId: string | null;
+  founderUserName: string | null;
+  founderUserEmail: string | null;
+  /** Set when Founder was entered by email before their first login. Null once promoted. */
+  founderProvisionalEmail: string | null;
+};
+
+export type FinanceApproverRecord = {
+  id: string;
+  /** Null for provisional (pre-registered) entries where the user has not yet signed in. */
+  userId: string | null;
+  email: string;
+  fullName: string | null;
+  isActive: boolean;
+  isPrimary: boolean;
+  /** Set when the approver was added by email before their first login. Null once promoted. */
+  provisionalEmail: string | null;
+};
+
+export type AdminCursorPaginationInput = {
+  cursor: string | null;
+  limit: number;
+};
+
+export type AdminCursorPaginatedResult<T> = {
+  data: T[];
+  nextCursor: string | null;
+  hasNextPage: boolean;
+};
+
+export type AdminClaimsFilters = {
+  status?: DbClaimStatus[];
+  departmentId?: string;
+  searchQuery?: string;
+  isActive?: boolean;
+};
+
+// ----------------------------------------------------------------
+// Logger interface — mirrors the claims domain pattern
+// ----------------------------------------------------------------
+
+export type AdminDomainLogger = {
+  info(event: string, payload?: Record<string, unknown>): void;
+  warn(event: string, payload?: Record<string, unknown>): void;
+  error(event: string, payload?: Record<string, unknown>): void;
+};
+
+// ----------------------------------------------------------------
+// Repository interface
+// ----------------------------------------------------------------
+
+export interface AdminRepository {
+  // Claims
+  getAllClaims(
+    filters: AdminClaimsFilters,
+    pagination: AdminCursorPaginationInput,
+  ): Promise<{
+    data: AdminCursorPaginatedResult<AdminClaimRecord> | null;
+    errorMessage: string | null;
+  }>;
+
+  softDeleteClaim(
+    claimId: string,
+    actorId: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }>;
+
+  // Master data (generic)
+  getMasterDataItems(
+    tableName: MasterDataTableName,
+  ): Promise<{ data: MasterDataItem[]; errorMessage: string | null }>;
+
+  createMasterDataItem(
+    tableName: MasterDataTableName,
+    name: string,
+  ): Promise<{ data: MasterDataItem | null; errorMessage: string | null }>;
+
+  updateMasterDataItem(
+    tableName: MasterDataTableName,
+    id: string,
+    payload: { name?: string; isActive?: boolean },
+  ): Promise<{ data: MasterDataItem | null; errorMessage: string | null }>;
+
+  // Departments + actors
+  getDepartmentsWithActors(): Promise<{
+    data: DepartmentWithActors[];
+    errorMessage: string | null;
+  }>;
+
+  updateDepartmentActors(
+    departmentId: string,
+    hodUserId: string,
+    founderUserId: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }>;
+
+  updateDepartmentActorsByEmail(
+    departmentId: string,
+    hodEmail: string,
+    founderEmail: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }>;
+
+  // Finance approvers
+  getFinanceApprovers(): Promise<{
+    data: FinanceApproverRecord[];
+    errorMessage: string | null;
+  }>;
+
+  createFinanceApprover(
+    userId: string,
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }>;
+
+  addFinanceApproverByEmail(
+    email: string,
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }>;
+
+  updateFinanceApprover(
+    id: string,
+    payload: { isActive?: boolean; isPrimary?: boolean },
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }>;
+
+  // Users
+  getAllUsers(pagination: AdminCursorPaginationInput): Promise<{
+    data: AdminCursorPaginatedResult<AdminUserRecord> | null;
+    errorMessage: string | null;
+  }>;
+
+  updateUserRole(
+    userId: string,
+    role: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }>;
+
+  // Admins
+  getAdmins(): Promise<{ data: AdminRecord[]; errorMessage: string | null }>;
+
+  addAdminByEmail(
+    email: string,
+  ): Promise<{ data: AdminRecord | null; errorMessage: string | null }>;
+
+  removeAdmin(adminId: string): Promise<{ success: boolean; errorMessage: string | null }>;
+}

--- a/src/modules/admin/actions.ts
+++ b/src/modules/admin/actions.ts
@@ -1,0 +1,414 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { logger } from "@/core/infra/logging/logger";
+import { ROUTES } from "@/core/config/route-registry";
+import { USER_ROLES } from "@/core/constants/auth";
+import { AdminSoftDeleteClaimService } from "@/core/domain/admin/AdminSoftDeleteClaimService";
+import { ManageMasterDataService } from "@/core/domain/admin/ManageMasterDataService";
+import { ManageActorsService } from "@/core/domain/admin/ManageActorsService";
+import { ManageAdminsService } from "@/core/domain/admin/ManageAdminsService";
+import type { MasterDataTableName } from "@/core/domain/admin/contracts";
+import { isAdmin } from "@/modules/admin/server/is-admin";
+import { SupabaseAdminRepository } from "@/modules/admin/repositories/SupabaseAdminRepository";
+import { SupabaseServerAuthRepository } from "@/modules/auth/repositories/supabase-server-auth.repository";
+
+// ----------------------------------------------------------------
+// Shared instances (singleton-per-request via module scope)
+// ----------------------------------------------------------------
+
+const adminRepository = new SupabaseAdminRepository();
+const authRepository = new SupabaseServerAuthRepository();
+const softDeleteService = new AdminSoftDeleteClaimService({ repository: adminRepository, logger });
+const manageMasterDataService = new ManageMasterDataService({
+  repository: adminRepository,
+  logger,
+});
+const manageActorsService = new ManageActorsService({ repository: adminRepository, logger });
+const manageAdminsService = new ManageAdminsService({ repository: adminRepository, logger });
+
+// ----------------------------------------------------------------
+// Shared Zod schemas
+// ----------------------------------------------------------------
+
+const idSchema = z.string().trim().min(1, "ID is required");
+
+const masterDataTableSchema = z.enum([
+  "master_expense_categories",
+  "master_products",
+  "master_locations",
+  "master_payment_modes",
+]);
+
+const userRoleSchema = z.enum([
+  USER_ROLES.employee,
+  USER_ROLES.hod,
+  USER_ROLES.founder,
+  USER_ROLES.finance,
+]);
+
+// ----------------------------------------------------------------
+// Admin guard helper
+// ----------------------------------------------------------------
+
+async function requireAdmin(): Promise<{ userId: string } | { forbidden: true }> {
+  const [adminCheck, userResult] = await Promise.all([isAdmin(), authRepository.getCurrentUser()]);
+
+  if (!adminCheck || userResult.errorMessage || !userResult.user) {
+    return { forbidden: true };
+  }
+
+  return { userId: userResult.user.id };
+}
+
+// ----------------------------------------------------------------
+// Actions
+// ----------------------------------------------------------------
+
+export async function softDeleteClaimAction(
+  claimId: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const parsed = idSchema.safeParse(claimId);
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.issues[0]?.message ?? "Invalid claim ID." };
+  }
+
+  const result = await softDeleteService.execute({
+    claimId: parsed.data,
+    actorId: guard.userId,
+  });
+
+  if (!result.success) {
+    return { ok: false, message: result.errorMessage ?? "Failed to soft-delete claim." };
+  }
+
+  revalidatePath(ROUTES.claims.myClaims);
+  revalidatePath(ROUTES.claims.detail(parsed.data));
+
+  return { ok: true };
+}
+
+export async function createMasterDataItemAction(
+  tableName: MasterDataTableName,
+  name: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const tableResult = masterDataTableSchema.safeParse(tableName);
+  if (!tableResult.success) {
+    return { ok: false, message: "Invalid master data table." };
+  }
+
+  const nameResult = z.string().trim().min(1, "Name is required").safeParse(name);
+  if (!nameResult.success) {
+    return { ok: false, message: nameResult.error.issues[0]?.message ?? "Invalid name." };
+  }
+
+  const result = await manageMasterDataService.createItem({
+    tableName: tableResult.data,
+    name: nameResult.data,
+  });
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function updateMasterDataItemAction(
+  tableName: MasterDataTableName,
+  id: string,
+  payload: { name?: string; isActive?: boolean },
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const tableResult = masterDataTableSchema.safeParse(tableName);
+  if (!tableResult.success) {
+    return { ok: false, message: "Invalid master data table." };
+  }
+
+  const idResult = idSchema.safeParse(id);
+  if (!idResult.success) {
+    return { ok: false, message: "Invalid item ID." };
+  }
+
+  const payloadSchema = z
+    .object({
+      name: z.string().trim().min(1).optional(),
+      isActive: z.boolean().optional(),
+    })
+    .refine((p) => p.name !== undefined || p.isActive !== undefined, {
+      message: "At least one field to update is required.",
+    });
+
+  const payloadResult = payloadSchema.safeParse(payload);
+  if (!payloadResult.success) {
+    return {
+      ok: false,
+      message: payloadResult.error.issues[0]?.message ?? "Invalid payload.",
+    };
+  }
+
+  const result = await manageMasterDataService.updateItem({
+    tableName: tableResult.data,
+    id: idResult.data,
+    payload: payloadResult.data,
+  });
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function updateDepartmentActorsAction(
+  departmentId: string,
+  hodUserId: string,
+  founderUserId: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const schema = z.object({
+    departmentId: idSchema,
+    hodUserId: idSchema,
+    founderUserId: idSchema,
+  });
+
+  const parsed = schema.safeParse({ departmentId, hodUserId, founderUserId });
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+
+  const result = await manageActorsService.updateDepartmentActors(parsed.data);
+
+  if (!result.success) {
+    return { ok: false, message: result.errorMessage ?? "Failed to update department actors." };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function updateDepartmentActorsByEmailAction(
+  departmentId: string,
+  hodEmail: string,
+  founderEmail: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const schema = z.object({
+    departmentId: idSchema,
+    hodEmail: z.string().trim().email(),
+    founderEmail: z.string().trim().email(),
+  });
+
+  const parsed = schema.safeParse({ departmentId, hodEmail, founderEmail });
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+
+  const result = await manageActorsService.updateDepartmentActorsByEmail({
+    departmentId: parsed.data.departmentId,
+    hodEmail: parsed.data.hodEmail,
+    founderEmail: parsed.data.founderEmail,
+  });
+
+  if (!result.success) {
+    return { ok: false, message: result.errorMessage ?? "Failed to update department actors." };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function createFinanceApproverAction(
+  userId: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const parsed = idSchema.safeParse(userId);
+  if (!parsed.success) {
+    return { ok: false, message: "Invalid user ID." };
+  }
+
+  const result = await manageActorsService.createFinanceApprover({ userId: parsed.data });
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function addFinanceApproverByEmailAction(
+  email: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const emailResult = z.string().trim().email("Invalid email address.").safeParse(email);
+  if (!emailResult.success) {
+    return { ok: false, message: emailResult.error.issues[0]?.message ?? "Invalid email." };
+  }
+
+  const result = await manageActorsService.addFinanceApproverByEmail({ email: emailResult.data });
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function updateFinanceApproverAction(
+  id: string,
+  payload: { isActive?: boolean; isPrimary?: boolean },
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const idResult = idSchema.safeParse(id);
+  if (!idResult.success) {
+    return { ok: false, message: "Invalid finance approver ID." };
+  }
+
+  const payloadSchema = z
+    .object({
+      isActive: z.boolean().optional(),
+      isPrimary: z.boolean().optional(),
+    })
+    .refine((p) => p.isActive !== undefined || p.isPrimary !== undefined, {
+      message: "At least one field to update is required.",
+    });
+
+  const payloadResult = payloadSchema.safeParse(payload);
+  if (!payloadResult.success) {
+    return { ok: false, message: payloadResult.error.issues[0]?.message ?? "Invalid payload." };
+  }
+
+  const result = await manageActorsService.updateFinanceApprover({
+    id: idResult.data,
+    payload: payloadResult.data,
+  });
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function updateUserRoleAction(
+  userId: string,
+  role: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const idResult = idSchema.safeParse(userId);
+  if (!idResult.success) {
+    return { ok: false, message: "Invalid user ID." };
+  }
+
+  const roleResult = userRoleSchema.safeParse(role);
+  if (!roleResult.success) {
+    return { ok: false, message: "Invalid role value." };
+  }
+
+  const result = await adminRepository.updateUserRole(idResult.data, roleResult.data);
+
+  if (!result.success) {
+    return { ok: false, message: result.errorMessage ?? "Failed to update user role." };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function addAdminAction(email: string): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const parsed = z.string().trim().email("Invalid email address.").safeParse(email);
+  if (!parsed.success) {
+    return { ok: false, message: parsed.error.flatten().formErrors[0] ?? "Invalid email address." };
+  }
+
+  const result = await manageAdminsService.addAdminByEmail(parsed.data);
+
+  if (result.errorMessage) {
+    return { ok: false, message: result.errorMessage };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}
+
+export async function removeAdminAction(
+  adminId: string,
+): Promise<{ ok: boolean; message?: string }> {
+  const guard = await requireAdmin();
+  if ("forbidden" in guard) {
+    return { ok: false, message: "Forbidden: admin access required." };
+  }
+
+  const parsed = idSchema.safeParse(adminId);
+  if (!parsed.success) {
+    return { ok: false, message: "Invalid admin record ID." };
+  }
+
+  const result = await manageAdminsService.removeAdmin(parsed.data);
+
+  if (!result.success) {
+    return { ok: false, message: result.errorMessage ?? "Failed to remove admin." };
+  }
+
+  revalidatePath(ROUTES.admin.settings);
+
+  return { ok: true };
+}

--- a/src/modules/admin/repositories/SupabaseAdminRepository.ts
+++ b/src/modules/admin/repositories/SupabaseAdminRepository.ts
@@ -1,0 +1,762 @@
+import { getServiceRoleSupabaseClient } from "@/core/infra/supabase/server-client";
+import type {
+  AdminClaimRecord,
+  AdminClaimsFilters,
+  AdminCursorPaginatedResult,
+  AdminCursorPaginationInput,
+  AdminRecord,
+  AdminRepository,
+  AdminUserRecord,
+  DepartmentWithActors,
+  FinanceApproverRecord,
+  MasterDataItem,
+  MasterDataTableName,
+} from "@/core/domain/admin/contracts";
+
+// ----------------------------------------------------------------
+// Shared normalizers
+// ----------------------------------------------------------------
+
+function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
+  if (!value) return null;
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value;
+}
+
+function normalizeAmount(value: number | string | null): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = typeof value === "string" ? parseFloat(value) : value;
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+// ----------------------------------------------------------------
+// Raw row types (Supabase response shapes)
+// ----------------------------------------------------------------
+
+type EnterpriseDashboardRow = {
+  claim_id: string;
+  employee_name: string;
+  employee_id: string;
+  department_name: string;
+  type_of_claim: string;
+  amount: number | string;
+  status: string;
+  submitted_on: string;
+  hod_action_date: string | null;
+  finance_action_date: string | null;
+  detail_type: "expense" | "advance";
+  submission_type: "Self" | "On Behalf";
+  is_active: boolean;
+  department_id: string | null;
+};
+
+type UserNameRow = { full_name: string | null; email: string };
+
+type DepartmentActorRow = {
+  id: string;
+  name: string;
+  is_active: boolean;
+  hod_user_id: string | null;
+  founder_user_id: string | null;
+  hod_provisional_email: string | null;
+  founder_provisional_email: string | null;
+  hod: UserNameRow | UserNameRow[] | null;
+  founder: UserNameRow | UserNameRow[] | null;
+};
+
+type FinanceApproverRow = {
+  id: string;
+  user_id: string | null;
+  is_active: boolean;
+  is_primary: boolean;
+  provisional_email: string | null;
+  user: UserNameRow | UserNameRow[] | null;
+};
+
+type UserRow = {
+  id: string;
+  email: string;
+  full_name: string | null;
+  role: string;
+  is_active: boolean;
+  created_at: string;
+};
+
+type AdminRow = {
+  id: string;
+  user_id: string | null;
+  provisional_email: string | null;
+  created_at: string;
+  user: UserNameRow | UserNameRow[] | null;
+};
+
+type MasterDataRow = {
+  id: string;
+  name: string;
+  is_active: boolean;
+};
+
+// ----------------------------------------------------------------
+// Repository implementation
+// ----------------------------------------------------------------
+
+export class SupabaseAdminRepository implements AdminRepository {
+  private get client() {
+    return getServiceRoleSupabaseClient();
+  }
+
+  // ─── Claims ───────────────────────────────────────────────────
+
+  async getAllClaims(
+    filters: AdminClaimsFilters,
+    pagination: AdminCursorPaginationInput,
+  ): Promise<{
+    data: AdminCursorPaginatedResult<AdminClaimRecord> | null;
+    errorMessage: string | null;
+  }> {
+    const limit = pagination.limit + 1;
+
+    let query = this.client
+      .from("vw_enterprise_claims_dashboard")
+      .select(
+        "claim_id, employee_name, employee_id, department_name, type_of_claim, amount, status, submitted_on, hod_action_date, finance_action_date, detail_type, submission_type, is_active, department_id",
+      )
+      .order("submitted_on", { ascending: false })
+      .order("claim_id", { ascending: false })
+      .limit(limit);
+
+    if (filters.status && filters.status.length > 0) {
+      query = query.in("status", filters.status);
+    }
+
+    if (filters.departmentId) {
+      query = query.eq("department_id", filters.departmentId);
+    }
+
+    if (filters.searchQuery) {
+      query = query.or(
+        `claim_id.ilike.%${filters.searchQuery}%,employee_name.ilike.%${filters.searchQuery}%,employee_id.ilike.%${filters.searchQuery}%`,
+      );
+    }
+
+    if (filters.isActive !== undefined) {
+      query = query.eq("is_active", filters.isActive);
+    }
+
+    if (pagination.cursor) {
+      query = query.lt("submitted_on", pagination.cursor);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const rows = (data ?? []) as EnterpriseDashboardRow[];
+    const hasNextPage = rows.length > pagination.limit;
+    const pageRows = hasNextPage ? rows.slice(0, pagination.limit) : rows;
+
+    const nextCursor = hasNextPage ? (pageRows[pageRows.length - 1]?.submitted_on ?? null) : null;
+
+    return {
+      data: {
+        data: pageRows.map((row) => ({
+          claimId: row.claim_id,
+          employeeName: row.employee_name,
+          employeeId: row.employee_id,
+          departmentName: row.department_name,
+          typeOfClaim: row.type_of_claim,
+          amount: normalizeAmount(row.amount),
+          status: row.status as AdminClaimRecord["status"],
+          submittedOn: row.submitted_on,
+          hodActionDate: row.hod_action_date,
+          financeActionDate: row.finance_action_date,
+          detailType: row.detail_type,
+          submissionType: row.submission_type,
+          isActive: row.is_active,
+          departmentId: row.department_id,
+        })),
+        nextCursor,
+        hasNextPage,
+      },
+      errorMessage: null,
+    };
+  }
+
+  async softDeleteClaim(
+    claimId: string,
+    actorId: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }> {
+    // Check if already inactive (idempotent)
+    const { data: existingClaim, error: fetchError } = await this.client
+      .from("claims")
+      .select("is_active")
+      .eq("id", claimId)
+      .single();
+
+    if (fetchError) {
+      return { success: false, errorMessage: fetchError.message };
+    }
+
+    if (!existingClaim) {
+      return { success: false, errorMessage: "Claim not found" };
+    }
+
+    if (!existingClaim.is_active) {
+      // Already soft-deleted — idempotent, treat as success
+      return { success: true, errorMessage: null };
+    }
+
+    // Soft-delete
+    const { error: updateError } = await this.client
+      .from("claims")
+      .update({ is_active: false })
+      .eq("id", claimId);
+
+    if (updateError) {
+      return { success: false, errorMessage: updateError.message };
+    }
+
+    // Write audit log
+    const { error: auditError } = await this.client.from("claim_audit_logs").insert({
+      claim_id: claimId,
+      actor_id: actorId,
+      action_type: "ADMIN_SOFT_DELETED",
+      assigned_to_id: null,
+      remarks: null,
+    });
+
+    if (auditError) {
+      // Audit log write failed — log as warning but don't roll back the soft-delete
+      return {
+        success: true,
+        errorMessage: `Soft-delete succeeded but audit log failed: ${auditError.message}`,
+      };
+    }
+
+    return { success: true, errorMessage: null };
+  }
+
+  // ─── Master data (generic) ────────────────────────────────────
+
+  async getMasterDataItems(
+    tableName: MasterDataTableName,
+  ): Promise<{ data: MasterDataItem[]; errorMessage: string | null }> {
+    const { data, error } = await this.client
+      .from(tableName)
+      .select("id, name, is_active")
+      .order("name", { ascending: true });
+
+    if (error) {
+      return { data: [], errorMessage: error.message };
+    }
+
+    return {
+      data: (data ?? []).map((row: MasterDataRow) => ({
+        id: row.id,
+        name: row.name,
+        isActive: row.is_active,
+      })),
+      errorMessage: null,
+    };
+  }
+
+  async createMasterDataItem(
+    tableName: MasterDataTableName,
+    name: string,
+  ): Promise<{ data: MasterDataItem | null; errorMessage: string | null }> {
+    const { data, error } = await this.client
+      .from(tableName)
+      .insert({ name: name.trim() })
+      .select("id, name, is_active")
+      .single();
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const row = data as MasterDataRow;
+    return {
+      data: { id: row.id, name: row.name, isActive: row.is_active },
+      errorMessage: null,
+    };
+  }
+
+  async updateMasterDataItem(
+    tableName: MasterDataTableName,
+    id: string,
+    payload: { name?: string; isActive?: boolean },
+  ): Promise<{ data: MasterDataItem | null; errorMessage: string | null }> {
+    const updatePayload: Record<string, unknown> = {};
+    if (payload.name !== undefined) updatePayload.name = payload.name.trim();
+    if (payload.isActive !== undefined) updatePayload.is_active = payload.isActive;
+
+    const { data, error } = await this.client
+      .from(tableName)
+      .update(updatePayload)
+      .eq("id", id)
+      .select("id, name, is_active")
+      .single();
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const row = data as MasterDataRow;
+    return {
+      data: { id: row.id, name: row.name, isActive: row.is_active },
+      errorMessage: null,
+    };
+  }
+
+  // ─── Departments + actors ─────────────────────────────────────
+
+  async getDepartmentsWithActors(): Promise<{
+    data: DepartmentWithActors[];
+    errorMessage: string | null;
+  }> {
+    const { data, error } = await this.client
+      .from("master_departments")
+      .select(
+        "id, name, is_active, hod_user_id, founder_user_id, hod_provisional_email, founder_provisional_email, hod:users!master_departments_hod_user_id_fkey(full_name, email), founder:users!master_departments_founder_user_id_fkey(full_name, email)",
+      )
+      .order("name", { ascending: true });
+
+    if (error) {
+      return { data: [], errorMessage: error.message };
+    }
+
+    return {
+      data: (data ?? []).map((row: DepartmentActorRow) => {
+        const hod = normalizeRelation(row.hod);
+        const founder = normalizeRelation(row.founder);
+
+        return {
+          id: row.id,
+          name: row.name,
+          isActive: row.is_active,
+          hodUserId: row.hod_user_id,
+          hodUserName: hod?.full_name ?? null,
+          hodUserEmail: hod?.email ?? null,
+          hodProvisionalEmail: row.hod_provisional_email,
+          founderUserId: row.founder_user_id,
+          founderUserName: founder?.full_name ?? null,
+          founderUserEmail: founder?.email ?? null,
+          founderProvisionalEmail: row.founder_provisional_email,
+        };
+      }),
+      errorMessage: null,
+    };
+  }
+
+  async updateDepartmentActors(
+    departmentId: string,
+    hodUserId: string,
+    founderUserId: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }> {
+    if (hodUserId === founderUserId) {
+      return { success: false, errorMessage: "HOD and Founder cannot be the same person." };
+    }
+
+    const { error } = await this.client
+      .from("master_departments")
+      .update({ hod_user_id: hodUserId, founder_user_id: founderUserId })
+      .eq("id", departmentId);
+
+    if (error) {
+      return { success: false, errorMessage: error.message };
+    }
+
+    return { success: true, errorMessage: null };
+  }
+
+  async updateDepartmentActorsByEmail(
+    departmentId: string,
+    hodEmail: string,
+    founderEmail: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }> {
+    // Look up HOD user by email
+    const { data: hodUser } = await this.client
+      .from("users")
+      .select("id")
+      .eq("email", hodEmail)
+      .maybeSingle();
+
+    // Look up Founder user by email
+    const { data: founderUser } = await this.client
+      .from("users")
+      .select("id")
+      .eq("email", founderEmail)
+      .maybeSingle();
+
+    const hodUserId = hodUser?.id ?? null;
+    const founderUserId = founderUser?.id ?? null;
+
+    if (hodUserId && founderUserId && hodUserId === founderUserId) {
+      return { success: false, errorMessage: "HOD and Founder cannot be the same person." };
+    }
+
+    const updatePayload: Record<string, unknown> = {
+      hod_user_id: hodUserId,
+      hod_provisional_email: hodUserId ? null : hodEmail,
+      founder_user_id: founderUserId,
+      founder_provisional_email: founderUserId ? null : founderEmail,
+    };
+
+    const { error } = await this.client
+      .from("master_departments")
+      .update(updatePayload)
+      .eq("id", departmentId);
+
+    if (error) {
+      return { success: false, errorMessage: error.message };
+    }
+
+    return { success: true, errorMessage: null };
+  }
+
+  // ─── Finance approvers ────────────────────────────────────────
+
+  async getFinanceApprovers(): Promise<{
+    data: FinanceApproverRecord[];
+    errorMessage: string | null;
+  }> {
+    const { data, error } = await this.client
+      .from("master_finance_approvers")
+      .select(
+        "id, user_id, is_active, is_primary, provisional_email, user:users!master_finance_approvers_user_id_fkey(full_name, email)",
+      )
+      .order("is_primary", { ascending: false });
+
+    if (error) {
+      return { data: [], errorMessage: error.message };
+    }
+
+    return {
+      data: (data ?? []).map((row: FinanceApproverRow) => {
+        const user = normalizeRelation(row.user);
+        return {
+          id: row.id,
+          userId: row.user_id,
+          email: user?.email ?? row.provisional_email ?? "",
+          fullName: user?.full_name ?? null,
+          isActive: row.is_active,
+          isPrimary: row.is_primary,
+          provisionalEmail: row.provisional_email,
+        };
+      }),
+      errorMessage: null,
+    };
+  }
+
+  async createFinanceApprover(
+    userId: string,
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }> {
+    const { data, error } = await this.client
+      .from("master_finance_approvers")
+      .insert({ user_id: userId })
+      .select(
+        "id, user_id, is_active, is_primary, provisional_email, user:users!master_finance_approvers_user_id_fkey(full_name, email)",
+      )
+      .single();
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const row = data as FinanceApproverRow;
+    const user = normalizeRelation(row.user);
+    return {
+      data: {
+        id: row.id,
+        userId: row.user_id,
+        email: user?.email ?? row.provisional_email ?? "",
+        fullName: user?.full_name ?? null,
+        isActive: row.is_active,
+        isPrimary: row.is_primary,
+        provisionalEmail: row.provisional_email,
+      },
+      errorMessage: null,
+    };
+  }
+
+  async updateFinanceApprover(
+    id: string,
+    payload: { isActive?: boolean; isPrimary?: boolean },
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }> {
+    const updatePayload: Record<string, unknown> = {};
+    if (payload.isActive !== undefined) updatePayload.is_active = payload.isActive;
+    if (payload.isPrimary !== undefined) updatePayload.is_primary = payload.isPrimary;
+
+    const { data, error } = await this.client
+      .from("master_finance_approvers")
+      .update(updatePayload)
+      .eq("id", id)
+      .select(
+        "id, user_id, is_active, is_primary, provisional_email, user:users!master_finance_approvers_user_id_fkey(full_name, email)",
+      )
+      .single();
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const row = data as FinanceApproverRow;
+    const user = normalizeRelation(row.user);
+    return {
+      data: {
+        id: row.id,
+        userId: row.user_id,
+        email: user?.email ?? row.provisional_email ?? "",
+        fullName: user?.full_name ?? null,
+        isActive: row.is_active,
+        isPrimary: row.is_primary,
+        provisionalEmail: row.provisional_email,
+      },
+      errorMessage: null,
+    };
+  }
+
+  async addFinanceApproverByEmail(
+    email: string,
+  ): Promise<{ data: FinanceApproverRecord | null; errorMessage: string | null }> {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    // 1. Check if user already exists in the users table
+    const { data: existingUser } = await this.client
+      .from("users")
+      .select("id")
+      .eq("email", normalizedEmail)
+      .maybeSingle();
+
+    // 2. Check for an existing finance approver entry by provisional_email or user_id
+    let approverCheckQuery = this.client
+      .from("master_finance_approvers")
+      .select("id")
+      .eq("provisional_email", normalizedEmail);
+
+    if (existingUser) {
+      approverCheckQuery = this.client
+        .from("master_finance_approvers")
+        .select("id")
+        .or(`provisional_email.eq.${normalizedEmail},user_id.eq.${existingUser.id}`);
+    }
+
+    const { data: existingApprover } = await approverCheckQuery.maybeSingle();
+
+    if (existingApprover) {
+      return {
+        data: null,
+        errorMessage: "This email is already registered as a finance approver.",
+      };
+    }
+
+    if (existingUser) {
+      // User already exists — create a fully-linked entry
+      return this.createFinanceApprover(existingUser.id);
+    }
+
+    // User hasn't logged in yet — create provisional entry
+    const { data, error } = await this.client
+      .from("master_finance_approvers")
+      .insert({ provisional_email: normalizedEmail })
+      .select("id, user_id, is_active, is_primary, provisional_email")
+      .single();
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const row = data as FinanceApproverRow;
+    return {
+      data: {
+        id: row.id,
+        userId: null,
+        email: normalizedEmail,
+        fullName: null,
+        isActive: row.is_active,
+        isPrimary: row.is_primary,
+        provisionalEmail: normalizedEmail,
+      },
+      errorMessage: null,
+    };
+  }
+
+  // ─── Users ────────────────────────────────────────────────────
+
+  async getAllUsers(pagination: AdminCursorPaginationInput): Promise<{
+    data: AdminCursorPaginatedResult<AdminUserRecord> | null;
+    errorMessage: string | null;
+  }> {
+    const limit = pagination.limit + 1;
+
+    let query = this.client
+      .from("users")
+      .select("id, email, full_name, role, is_active, created_at")
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .limit(limit);
+
+    if (pagination.cursor) {
+      query = query.lt("created_at", pagination.cursor);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return { data: null, errorMessage: error.message };
+    }
+
+    const rows = (data ?? []) as UserRow[];
+    const hasNextPage = rows.length > pagination.limit;
+    const pageRows = hasNextPage ? rows.slice(0, pagination.limit) : rows;
+    const nextCursor = hasNextPage ? (pageRows[pageRows.length - 1]?.created_at ?? null) : null;
+
+    return {
+      data: {
+        data: pageRows.map((row) => ({
+          id: row.id,
+          email: row.email,
+          fullName: row.full_name,
+          role: row.role,
+          isActive: row.is_active,
+          createdAt: row.created_at,
+        })),
+        nextCursor,
+        hasNextPage,
+      },
+      errorMessage: null,
+    };
+  }
+
+  async updateUserRole(
+    userId: string,
+    role: string,
+  ): Promise<{ success: boolean; errorMessage: string | null }> {
+    const { error } = await this.client.from("users").update({ role }).eq("id", userId);
+
+    if (error) {
+      return { success: false, errorMessage: error.message };
+    }
+
+    return { success: true, errorMessage: null };
+  }
+
+  // ─── Admins ───────────────────────────────────────────────────
+
+  async getAdmins(): Promise<{ data: AdminRecord[]; errorMessage: string | null }> {
+    const { data, error } = await this.client
+      .from("admins")
+      .select(
+        "id, user_id, provisional_email, created_at, user:users!admins_user_id_fkey(full_name, email)",
+      )
+      .order("created_at", { ascending: true });
+
+    if (error) {
+      return { data: [], errorMessage: error.message };
+    }
+
+    return {
+      data: (data ?? []).map((row: AdminRow) => {
+        const user = normalizeRelation(row.user);
+        return {
+          id: row.id,
+          userId: row.user_id,
+          email: user?.email ?? row.provisional_email ?? "",
+          fullName: user?.full_name ?? null,
+          createdAt: row.created_at,
+          provisionalEmail: row.provisional_email,
+        };
+      }),
+      errorMessage: null,
+    };
+  }
+
+  async addAdminByEmail(
+    email: string,
+  ): Promise<{ data: AdminRecord | null; errorMessage: string | null }> {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    // 1. Check if user already exists
+    const { data: existingUser } = await this.client
+      .from("users")
+      .select("id")
+      .eq("email", normalizedEmail)
+      .maybeSingle();
+
+    // 2. Duplicate check (by provisional_email or user_id)
+    const { data: existingAdmin } = await this.client
+      .from("admins")
+      .select("id")
+      .or(
+        existingUser
+          ? `provisional_email.eq.${normalizedEmail},user_id.eq.${existingUser.id}`
+          : `provisional_email.eq.${normalizedEmail}`,
+      )
+      .maybeSingle();
+
+    if (existingAdmin) {
+      return { data: null, errorMessage: "This email is already registered as an admin." };
+    }
+
+    if (existingUser) {
+      // User exists — create a fully-linked entry immediately
+      const { data, error } = await this.client
+        .from("admins")
+        .insert({ user_id: existingUser.id })
+        .select(
+          "id, user_id, provisional_email, created_at, user:users!admins_user_id_fkey(full_name, email)",
+        )
+        .single();
+
+      if (error) return { data: null, errorMessage: error.message };
+
+      const row = data as AdminRow;
+      const user = normalizeRelation(row.user);
+      return {
+        data: {
+          id: row.id,
+          userId: row.user_id,
+          email: user?.email ?? normalizedEmail,
+          fullName: user?.full_name ?? null,
+          createdAt: row.created_at,
+          provisionalEmail: null,
+        },
+        errorMessage: null,
+      };
+    }
+
+    // User hasn't logged in yet — create provisional entry (user_id = null)
+    const { data, error } = await this.client
+      .from("admins")
+      .insert({ provisional_email: normalizedEmail })
+      .select("id, user_id, provisional_email, created_at")
+      .single();
+
+    if (error) return { data: null, errorMessage: error.message };
+
+    const row = data as AdminRow;
+    return {
+      data: {
+        id: row.id,
+        userId: null,
+        email: normalizedEmail,
+        fullName: null,
+        createdAt: row.created_at,
+        provisionalEmail: normalizedEmail,
+      },
+      errorMessage: null,
+    };
+  }
+
+  async removeAdmin(adminId: string): Promise<{ success: boolean; errorMessage: string | null }> {
+    const { error } = await this.client.from("admins").delete().eq("id", adminId);
+
+    if (error) {
+      return { success: false, errorMessage: error.message };
+    }
+
+    return { success: true, errorMessage: null };
+  }
+}

--- a/src/modules/admin/server/is-admin.ts
+++ b/src/modules/admin/server/is-admin.ts
@@ -1,0 +1,65 @@
+import { cache } from "react";
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { serverEnv } from "@/core/config/server-env";
+import { logger } from "@/core/infra/logging/logger";
+
+/**
+ * Returns true if the currently authenticated user exists in the `admins` table.
+ * Wrapped in React.cache() so the DB query is deduplicated within a single request.
+ */
+export const isAdmin = cache(async (): Promise<boolean> => {
+  try {
+    const cookieStore = await cookies();
+
+    const supabase = createServerClient(
+      serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+      serverEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              try {
+                cookieStore.set(name, value, options);
+              } catch {
+                // Server components may not set cookies; safe to ignore.
+              }
+            });
+          },
+        },
+      },
+    );
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return false;
+    }
+
+    const { count, error } = await supabase
+      .from("admins")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id);
+
+    if (error) {
+      logger.warn("admin.is_admin.query_failed", {
+        userId: user.id,
+        error: error.message,
+        code: error.code,
+      });
+      return false;
+    }
+
+    const result = (count ?? 0) > 0;
+    logger.debug("admin.is_admin.check_complete", { userId: user.id, count, result });
+    return result;
+  } catch {
+    return false;
+  }
+});

--- a/src/modules/admin/ui/admin-claims-section.tsx
+++ b/src/modules/admin/ui/admin-claims-section.tsx
@@ -1,0 +1,107 @@
+import { Suspense } from "react";
+import { logger } from "@/core/infra/logging/logger";
+import { GetAdminClaimsService } from "@/core/domain/admin/GetAdminClaimsService";
+import { SupabaseAdminRepository } from "@/modules/admin/repositories/SupabaseAdminRepository";
+import { AdminClaimsTable } from "@/modules/admin/ui/admin-claims-table";
+import { MyClaimsPaginationControls } from "@/modules/claims/ui/my-claims-pagination-controls";
+import { TableSkeleton } from "@/components/ui/table-skeleton";
+import type { DbClaimStatus } from "@/core/constants/statuses";
+import type { AdminClaimsFilters } from "@/core/domain/admin/contracts";
+import { DB_CLAIM_STATUSES } from "@/core/constants/statuses";
+
+type SearchParamsValue = string | string[] | undefined;
+
+function firstParamValue(value: SearchParamsValue): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function toSearchParams(searchParams?: Record<string, SearchParamsValue>): URLSearchParams {
+  const params = new URLSearchParams();
+  if (!searchParams) return params;
+  for (const [key, value] of Object.entries(searchParams)) {
+    const normalized = firstParamValue(value);
+    if (normalized) params.set(key, normalized);
+  }
+  return params;
+}
+
+function normalizeStatusFilter(value: string | undefined): DbClaimStatus[] | undefined {
+  if (!value) return undefined;
+  const parsed = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry): entry is DbClaimStatus => DB_CLAIM_STATUSES.includes(entry as DbClaimStatus));
+  return parsed.length === 0 ? undefined : parsed;
+}
+
+const PAGE_SIZE = 10;
+
+async function AdminClaimsTableSection({
+  searchParams,
+}: {
+  searchParams?: Record<string, SearchParamsValue>;
+}) {
+  const adminRepository = new SupabaseAdminRepository();
+  const service = new GetAdminClaimsService({ repository: adminRepository, logger });
+
+  const cursor = firstParamValue(searchParams?.cursor) ?? null;
+  const previousCursor = firstParamValue(searchParams?.prevCursor) ?? null;
+  const previousCursorToken = previousCursor ?? (cursor ? "__first__" : null);
+
+  const filters: AdminClaimsFilters = {
+    status: normalizeStatusFilter(firstParamValue(searchParams?.status)),
+    departmentId: firstParamValue(searchParams?.department_id)?.trim() || undefined,
+    searchQuery: firstParamValue(searchParams?.search_query)?.trim() || undefined,
+  };
+
+  const result = await service.execute({
+    filters,
+    pagination: { cursor, limit: PAGE_SIZE },
+  });
+
+  if (result.errorMessage || !result.data) {
+    return (
+      <div className="px-4 py-6">
+        <p className="rounded-xl bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:bg-rose-950/40 dark:text-rose-200">
+          Unable to load claims. {result.errorMessage ?? "Unknown error"}
+        </p>
+      </div>
+    );
+  }
+
+  const { data: rows, nextCursor, hasNextPage } = result.data;
+
+  return (
+    <>
+      <AdminClaimsTable rows={rows} />
+      <MyClaimsPaginationControls
+        hasNextPage={hasNextPage}
+        hasPreviousPage={Boolean(previousCursorToken)}
+        currentCursor={cursor}
+        nextCursor={nextCursor}
+        previousCursor={previousCursorToken}
+        searchParams={searchParams}
+      />
+    </>
+  );
+}
+
+export function AdminClaimsSection({
+  searchParams,
+}: {
+  searchParams?: Record<string, SearchParamsValue>;
+}) {
+  return (
+    <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.14em] text-zinc-700 dark:text-zinc-300">
+          Admin Overview — All Claims
+        </h2>
+      </div>
+      <Suspense fallback={<TableSkeleton />}>
+        <AdminClaimsTableSection searchParams={searchParams} />
+      </Suspense>
+    </section>
+  );
+}

--- a/src/modules/admin/ui/admin-claims-table.tsx
+++ b/src/modules/admin/ui/admin-claims-table.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ROUTES } from "@/core/config/route-registry";
+import { softDeleteClaimAction } from "@/modules/admin/actions";
+import { ClaimStatusBadge } from "@/modules/claims/ui/claim-status-badge";
+import type { AdminClaimRecord } from "@/core/domain/admin/contracts";
+import { formatDate, formatCurrency } from "@/lib/format";
+
+type Props = {
+  rows: AdminClaimRecord[];
+};
+
+export function AdminClaimsTable({ rows }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div className="grid place-items-center px-4 py-14 text-center">
+        <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">No claims found</p>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+          Adjust filters or check back later.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <table className="min-w-[1600px] divide-y divide-zinc-200 text-left text-sm dark:divide-zinc-800">
+        <thead className="bg-zinc-50 text-xs uppercase tracking-[0.12em] text-zinc-600 dark:bg-zinc-900/50 dark:text-zinc-400">
+          <tr>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">CLAIM ID</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">EMPLOYEE ID</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">EMPLOYEE NAME</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">DEPARTMENT</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">TYPE</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">AMOUNT</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">STATUS</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">ACTIVE</th>
+            <th className="whitespace-nowrap px-4 py-3 font-semibold">SUBMITTED ON</th>
+            <th className="whitespace-nowrap px-4 py-3 text-right font-semibold">ACTIONS</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-100 bg-white text-zinc-700 dark:divide-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+          {rows.map((claim) => (
+            <AdminClaimRow key={claim.claimId} claim={claim} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AdminClaimRow({ claim }: { claim: AdminClaimRecord }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleSoftDelete() {
+    startTransition(async () => {
+      const result = await softDeleteClaimAction(claim.claimId);
+      if (result.ok) {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <tr className="transition-colors hover:bg-zinc-50/70 dark:hover:bg-zinc-900/40">
+      <td className="whitespace-nowrap px-4 py-3 font-medium text-zinc-900 dark:text-zinc-100">
+        <Link
+          href={ROUTES.claims.detail(claim.claimId)}
+          className="text-indigo-500 hover:text-indigo-400 hover:underline"
+        >
+          {claim.claimId}
+        </Link>
+      </td>
+      <td className="whitespace-nowrap px-4 py-3">
+        <span className="inline-block max-w-[180px] truncate align-bottom">{claim.employeeId}</span>
+      </td>
+      <td className="px-4 py-3">
+        <span className="inline-block max-w-[220px] truncate align-bottom">
+          {claim.employeeName}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        <span className="inline-block max-w-[200px] truncate align-bottom">
+          {claim.departmentName}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        <span className="inline-block max-w-[180px] truncate align-bottom">
+          {claim.typeOfClaim}
+        </span>
+      </td>
+      <td className="whitespace-nowrap px-4 py-3 font-semibold text-zinc-900 dark:text-zinc-100">
+        {formatCurrency(claim.amount)}
+      </td>
+      <td className="whitespace-nowrap px-4 py-3">
+        <ClaimStatusBadge status={claim.status} />
+      </td>
+      <td className="whitespace-nowrap px-4 py-3">
+        {claim.isActive ? (
+          <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+            Active
+          </span>
+        ) : (
+          <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+            Soft-deleted
+          </span>
+        )}
+      </td>
+      <td className="whitespace-nowrap px-4 py-3">{formatDate(claim.submittedOn)}</td>
+      <td className="whitespace-nowrap px-4 py-3 text-right">
+        {claim.isActive ? (
+          <button
+            type="button"
+            onClick={handleSoftDelete}
+            disabled={isPending}
+            className="inline-flex h-7 items-center rounded-lg border border-rose-300 bg-rose-50 px-2.5 text-xs font-semibold text-rose-700 transition-colors hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-700 dark:bg-rose-950/30 dark:text-rose-300 dark:hover:bg-rose-950/60"
+          >
+            {isPending ? "Deleting…" : "Soft Delete"}
+          </button>
+        ) : (
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">Already deleted</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/modules/admin/ui/admin-soft-delete-panel.tsx
+++ b/src/modules/admin/ui/admin-soft-delete-panel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/core/config/route-registry";
+import { softDeleteClaimAction } from "@/modules/admin/actions";
+
+type Props = {
+  claimId: string;
+};
+
+export function AdminSoftDeletePanel({ claimId }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleSoftDelete() {
+    setError(null);
+    startTransition(async () => {
+      const result = await softDeleteClaimAction(claimId);
+      if (result.ok) {
+        router.push(`${ROUTES.claims.myClaims}?view=admin`);
+      } else {
+        setError(result.message ?? "Failed to soft-delete claim.");
+        setConfirming(false);
+      }
+    });
+  }
+
+  return (
+    <section className="rounded-2xl border border-rose-200 bg-rose-50 p-4 shadow-sm dark:border-rose-800/40 dark:bg-rose-950/20">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-rose-700 dark:text-rose-300">
+            Admin Control
+          </h2>
+          <p className="mt-0.5 text-xs text-rose-600/80 dark:text-rose-400/80">
+            Soft-delete this claim. It will be hidden from all submitter and approver views. This
+            action is reversible only via direct database access.
+          </p>
+        </div>
+
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="whitespace-nowrap rounded-lg border border-rose-400 bg-white px-3 py-1.5 text-sm font-semibold text-rose-700 transition-colors hover:bg-rose-100 dark:border-rose-600 dark:bg-transparent dark:text-rose-300 dark:hover:bg-rose-950/40"
+          >
+            Soft Delete Claim
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-rose-700 dark:text-rose-300">
+              Are you sure?
+            </span>
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={handleSoftDelete}
+              className="rounded-lg bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? "Deleting…" : "Yes, Delete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={isPending}
+              className="rounded-lg border border-rose-300 px-3 py-1.5 text-sm font-semibold text-rose-700 hover:bg-rose-100 disabled:opacity-50 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-950/40"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+
+      {error ? <p className="mt-2 text-xs text-rose-700 dark:text-rose-300">{error}</p> : null}
+    </section>
+  );
+}

--- a/src/modules/admin/ui/settings/admins-management.tsx
+++ b/src/modules/admin/ui/settings/admins-management.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { AdminRecord } from "@/core/domain/admin/contracts";
+import { addAdminAction, removeAdminAction } from "@/modules/admin/actions";
+
+type Props = {
+  admins: AdminRecord[];
+};
+
+export function AdminsManagement({ admins }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [newEmail, setNewEmail] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+
+  function handleAdd() {
+    const email = newEmail.trim();
+    if (!email) {
+      setAddError("Email is required.");
+      return;
+    }
+    setAddError(null);
+    startTransition(async () => {
+      const result = await addAdminAction(email);
+      if (result.ok) {
+        setNewEmail("");
+        router.refresh();
+      } else {
+        setAddError(result.message ?? "Failed to add admin.");
+      }
+    });
+  }
+
+  function handleRemove(adminId: string) {
+    startTransition(async () => {
+      await removeAdminAction(adminId);
+      setConfirmRemoveId(null);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-700 dark:text-zinc-300">
+          Administrators
+        </h3>
+      </div>
+
+      {admins.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-zinc-500">No admins configured yet.</p>
+      ) : (
+        <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+          {admins.map((admin) => (
+            <div
+              key={admin.id}
+              className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5"
+            >
+              <div>
+                <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  {admin.fullName ?? (admin.provisionalEmail ? "Pending first login" : "—")}
+                </p>
+                <p className="text-xs text-zinc-500">{admin.email}</p>
+                {admin.provisionalEmail ? (
+                  <span className="mt-0.5 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                    Pending login
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="flex items-center gap-2">
+                {confirmRemoveId === admin.id ? (
+                  <>
+                    <span className="text-xs text-zinc-500">Remove this admin?</span>
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => handleRemove(admin.id)}
+                      className="rounded-lg bg-rose-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-rose-500 disabled:opacity-50"
+                    >
+                      {isPending ? "Removing…" : "Confirm"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmRemoveId(null)}
+                      className="rounded-lg border border-zinc-300 px-2.5 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRemoveId(admin.id)}
+                    className="rounded-lg border border-rose-300 px-2.5 py-1 text-xs font-semibold text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-950/30"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          Promote user to Admin
+        </p>
+        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+          Enter the user&apos;s email address. If they haven&apos;t signed in yet, they will be
+          granted admin access automatically on their first login.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="email"
+            placeholder="user@example.com"
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            className="flex-1 rounded-lg border border-zinc-300 px-3 py-1.5 text-sm outline-none transition-colors focus:border-indigo-400 dark:border-zinc-700 dark:bg-zinc-800 dark:focus:border-indigo-500"
+          />
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={handleAdd}
+            className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            Promote
+          </button>
+        </div>
+        {addError ? <p className="mt-1 text-xs text-rose-600">{addError}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/admin/ui/settings/departments-management.tsx
+++ b/src/modules/admin/ui/settings/departments-management.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { DepartmentWithActors } from "@/core/domain/admin/contracts";
+import { updateDepartmentActorsByEmailAction } from "@/modules/admin/actions";
+
+type Props = {
+  departments: DepartmentWithActors[];
+};
+
+export function DepartmentsManagement({ departments }: Props) {
+  if (departments.length === 0) {
+    return (
+      <p className="rounded-xl border border-zinc-200 bg-white px-4 py-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900">
+        No departments found.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {departments.map((dept) => (
+        <DepartmentActorRow key={dept.id} department={dept} />
+      ))}
+    </div>
+  );
+}
+
+function DepartmentActorRow({ department }: { department: DepartmentWithActors }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  // Pre-fill from existing linked email or provisional email
+  const [hodEmail, setHodEmail] = useState(
+    department.hodUserEmail ?? department.hodProvisionalEmail ?? "",
+  );
+  const [founderEmail, setFounderEmail] = useState(
+    department.founderUserEmail ?? department.founderProvisionalEmail ?? "",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  function handleSave() {
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const result = await updateDepartmentActorsByEmailAction(
+        department.id,
+        hodEmail,
+        founderEmail,
+      );
+      if (result.ok) {
+        setSaved(true);
+        router.refresh();
+      } else {
+        setError(result.message ?? "Failed to update.");
+      }
+    });
+  }
+
+  const hodIsPending = !department.hodUserId && Boolean(department.hodProvisionalEmail);
+  const founderIsPending = !department.founderUserId && Boolean(department.founderProvisionalEmail);
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            {department.name}
+          </span>
+          {!department.isActive ? (
+            <span className="ml-2 inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+              Inactive
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <div>
+          <label className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            HOD
+            {hodIsPending ? (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                Pending first login
+              </span>
+            ) : null}
+          </label>
+          <input
+            type="email"
+            value={hodEmail}
+            onChange={(e) => {
+              setHodEmail(e.target.value);
+              setSaved(false);
+            }}
+            placeholder="hod@company.com"
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-800 outline-none transition-colors focus:border-indigo-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:border-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            Founder
+            {founderIsPending ? (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                Pending first login
+              </span>
+            ) : null}
+          </label>
+          <input
+            type="email"
+            value={founderEmail}
+            onChange={(e) => {
+              setFounderEmail(e.target.value);
+              setSaved(false);
+            }}
+            placeholder="founder@company.com"
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-800 outline-none transition-colors focus:border-indigo-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:border-indigo-500"
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          type="button"
+          disabled={isPending || !hodEmail || !founderEmail}
+          onClick={handleSave}
+          className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isPending ? "Saving…" : "Save Actors"}
+        </button>
+        {saved ? (
+          <span className="text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+            Saved ✓
+          </span>
+        ) : null}
+        {error ? <p className="text-xs text-rose-600">{error}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/admin/ui/settings/finance-approvers-management.tsx
+++ b/src/modules/admin/ui/settings/finance-approvers-management.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { FinanceApproverRecord } from "@/core/domain/admin/contracts";
+import {
+  addFinanceApproverByEmailAction,
+  updateFinanceApproverAction,
+} from "@/modules/admin/actions";
+
+type Props = {
+  approvers: FinanceApproverRecord[];
+};
+
+export function FinanceApproversManagement({ approvers }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [email, setEmail] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+
+  function handleAdd() {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setAddError("Please enter an email address.");
+      return;
+    }
+    setAddError(null);
+    startTransition(async () => {
+      const result = await addFinanceApproverByEmailAction(trimmed);
+      if (result.ok) {
+        setEmail("");
+        router.refresh();
+      } else {
+        setAddError(result.message ?? "Failed to add approver.");
+      }
+    });
+  }
+
+  function handleToggle(id: string, currentValue: boolean) {
+    startTransition(async () => {
+      await updateFinanceApproverAction(id, { isActive: !currentValue });
+      router.refresh();
+    });
+  }
+
+  function handleSetPrimary(id: string) {
+    startTransition(async () => {
+      await updateFinanceApproverAction(id, { isPrimary: true });
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-700 dark:text-zinc-300">
+          Finance Approvers
+        </h3>
+      </div>
+
+      {approvers.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-zinc-500">No finance approvers configured.</p>
+      ) : (
+        <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+          {approvers.map((approver) => (
+            <div
+              key={approver.id}
+              className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  {approver.provisionalEmail ? (
+                    <span className="italic text-zinc-500 dark:text-zinc-400">
+                      {approver.email}
+                    </span>
+                  ) : (
+                    (approver.fullName ?? "—")
+                  )}
+                  {approver.isPrimary ? (
+                    <span className="ml-2 inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                      Primary
+                    </span>
+                  ) : null}
+                  {approver.provisionalEmail ? (
+                    <span className="ml-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                      Pending first login
+                    </span>
+                  ) : null}
+                </p>
+                <p className="text-xs text-zinc-500">{approver.email}</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {!approver.provisionalEmail && !approver.isPrimary ? (
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => handleSetPrimary(approver.id)}
+                    className="rounded-lg border border-indigo-300 px-2.5 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 disabled:opacity-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950/30"
+                  >
+                    Set Primary
+                  </button>
+                ) : null}
+
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={() => handleToggle(approver.id, approver.isActive)}
+                  className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
+                    approver.isActive
+                      ? "border-zinc-300 text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                      : "border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-300 dark:hover:bg-emerald-950/30"
+                  }`}
+                >
+                  {approver.isActive ? "Deactivate" : "Activate"}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          Add Finance Approver
+        </p>
+        <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">
+          Enter their email. If they haven&apos;t logged in yet, they&apos;ll be granted access
+          automatically when they do.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAdd();
+            }}
+            placeholder="finance@example.com"
+            className="flex-1 rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-800 outline-none transition-colors focus:border-indigo-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:border-indigo-500"
+          />
+          <button
+            type="button"
+            disabled={isPending || !email.trim()}
+            onClick={handleAdd}
+            className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
+        {addError ? <p className="mt-1 text-xs text-rose-600">{addError}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/admin/ui/settings/master-data-table.tsx
+++ b/src/modules/admin/ui/settings/master-data-table.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { MasterDataItem, MasterDataTableName } from "@/core/domain/admin/contracts";
+import { createMasterDataItemAction, updateMasterDataItemAction } from "@/modules/admin/actions";
+
+type Props = {
+  tableName: MasterDataTableName;
+  displayName: string;
+  items: MasterDataItem[];
+};
+
+export function MasterDataTable({ tableName, displayName, items }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [addName, setAddName] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+
+  function handleAdd() {
+    const name = addName.trim();
+    if (!name) {
+      setAddError("Name is required.");
+      return;
+    }
+    setAddError(null);
+    startTransition(async () => {
+      const result = await createMasterDataItemAction(tableName, name);
+      if (result.ok) {
+        setAddName("");
+        router.refresh();
+      } else {
+        setAddError(result.message ?? "Failed to create item.");
+      }
+    });
+  }
+
+  function handleRename(id: string) {
+    const name = editName.trim();
+    if (!name) return;
+    startTransition(async () => {
+      const result = await updateMasterDataItemAction(tableName, id, { name });
+      if (result.ok) {
+        setEditingId(null);
+        setEditName("");
+        router.refresh();
+      }
+    });
+  }
+
+  function handleToggleActive(item: MasterDataItem) {
+    startTransition(async () => {
+      await updateMasterDataItemAction(tableName, item.id, { isActive: !item.isActive });
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-700 dark:text-zinc-300">
+          {displayName}
+        </h3>
+      </div>
+
+      <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+        {items.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-zinc-500">No items yet.</p>
+        ) : (
+          items.map((item) => (
+            <div key={item.id} className="flex items-center justify-between gap-3 px-4 py-2.5">
+              {editingId === item.id ? (
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleRename(item.id)}
+                  className="flex-1 rounded-lg border border-indigo-400 px-2 py-1 text-sm outline-none dark:border-indigo-500 dark:bg-zinc-800"
+                  autoFocus
+                />
+              ) : (
+                <span
+                  className={`flex-1 text-sm ${
+                    item.isActive
+                      ? "text-zinc-800 dark:text-zinc-200"
+                      : "text-zinc-400 line-through dark:text-zinc-500"
+                  }`}
+                >
+                  {item.name}
+                </span>
+              )}
+
+              <div className="flex items-center gap-2">
+                {editingId === item.id ? (
+                  <>
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => handleRename(item.id)}
+                      className="rounded-lg bg-indigo-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingId(null)}
+                      className="rounded-lg border border-zinc-300 px-2.5 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => {
+                      setEditingId(item.id);
+                      setEditName(item.name);
+                    }}
+                    className="rounded-lg border border-zinc-300 px-2.5 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    Rename
+                  </button>
+                )}
+
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={() => handleToggleActive(item)}
+                  className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
+                    item.isActive
+                      ? "border-zinc-300 text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                      : "border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-300 dark:hover:bg-emerald-950/30"
+                  }`}
+                >
+                  {item.isActive ? "Deactivate" : "Activate"}
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder={`Add new ${displayName.toLowerCase()} name…`}
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            className="flex-1 rounded-lg border border-zinc-300 px-3 py-1.5 text-sm outline-none transition-colors focus:border-indigo-400 dark:border-zinc-700 dark:bg-zinc-800 dark:focus:border-indigo-500"
+          />
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={handleAdd}
+            className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
+        {addError ? <p className="mt-1 text-xs text-rose-600">{addError}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/admin/ui/settings/users-management.tsx
+++ b/src/modules/admin/ui/settings/users-management.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { AdminUserRecord } from "@/core/domain/admin/contracts";
+import { USER_ROLES } from "@/core/constants/auth";
+import { updateUserRoleAction } from "@/modules/admin/actions";
+
+type Props = {
+  users: AdminUserRecord[];
+  hasNextPage: boolean;
+  nextCursor: string | null;
+  hasPreviousPage: boolean;
+  previousCursor: string | null;
+};
+
+const ROLE_OPTIONS = [
+  { value: USER_ROLES.employee, label: "Employee" },
+  { value: USER_ROLES.hod, label: "HOD" },
+  { value: USER_ROLES.founder, label: "Founder" },
+  { value: USER_ROLES.finance, label: "Finance" },
+];
+
+export function UsersManagement({
+  users,
+  hasNextPage,
+  nextCursor,
+  hasPreviousPage,
+  previousCursor,
+}: Props) {
+  const router = useRouter();
+
+  function buildHref(cursor: string | null, prevCursor: string | null): string {
+    const params = new URLSearchParams();
+    params.set("tab", "users");
+    if (cursor) params.set("cursor", cursor);
+    if (prevCursor) params.set("prevCursor", prevCursor);
+    return `?${params.toString()}`;
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-zinc-700 dark:text-zinc-300">
+          Users &amp; Roles
+        </h3>
+      </div>
+
+      {users.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-zinc-500">No users found.</p>
+      ) : (
+        <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+          {users.map((user) => (
+            <UserRoleRow key={user.id} user={user} onUpdated={() => router.refresh()} />
+          ))}
+        </div>
+      )}
+
+      {hasPreviousPage || hasNextPage ? (
+        <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <a
+            href={
+              hasPreviousPage && previousCursor
+                ? buildHref(previousCursor === "__first__" ? null : previousCursor, null)
+                : "#"
+            }
+            aria-disabled={!hasPreviousPage}
+            className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition-colors ${
+              hasPreviousPage
+                ? "border-zinc-300 text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                : "cursor-not-allowed border-zinc-200 text-zinc-400 dark:border-zinc-800 dark:text-zinc-600"
+            }`}
+          >
+            Previous
+          </a>
+          <a
+            href={hasNextPage && nextCursor ? buildHref(nextCursor, null) : "#"}
+            aria-disabled={!hasNextPage}
+            className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition-colors ${
+              hasNextPage
+                ? "border-zinc-300 text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                : "cursor-not-allowed border-zinc-200 text-zinc-400 dark:border-zinc-800 dark:text-zinc-600"
+            }`}
+          >
+            Next
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function UserRoleRow({ user, onUpdated }: { user: AdminUserRecord; onUpdated: () => void }) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleRoleChange(newRole: string) {
+    startTransition(async () => {
+      await updateUserRoleAction(user.id, newRole);
+      onUpdated();
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
+      <div>
+        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          {user.fullName ?? "—"}
+        </p>
+        <p className="text-xs text-zinc-500">{user.email}</p>
+      </div>
+
+      <select
+        value={user.role}
+        disabled={isPending}
+        onChange={(e) => handleRoleChange(e.target.value)}
+        className="rounded-lg border border-zinc-300 bg-white px-2.5 py-1.5 text-sm text-zinc-800 outline-none transition-colors focus:border-indigo-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:border-indigo-500"
+      >
+        {ROLE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/modules/claims/repositories/SupabaseClaimRepository.ts
+++ b/src/modules/claims/repositories/SupabaseClaimRepository.ts
@@ -110,8 +110,8 @@ type ClaimAuditLogRow = {
 };
 
 type DepartmentApproverRoleRow = {
-  approver_1: string | null;
-  approver_2: string | null;
+  hod_user_id: string | null;
+  founder_user_id: string | null;
 };
 
 type GetPendingApprovalsRow = {
@@ -1656,9 +1656,9 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const [departmentRoleResult, financeRoleResult] = await Promise.all([
       client
         .from("master_departments")
-        .select("approver_1, approver_2")
+        .select("hod_user_id, founder_user_id")
         .eq("is_active", true)
-        .or(`approver_1.eq.${userId},approver_2.eq.${userId}`),
+        .or(`hod_user_id.eq.${userId},founder_user_id.eq.${userId}`),
       client
         .from("master_finance_approvers")
         .select("id")
@@ -1685,8 +1685,8 @@ export class SupabaseClaimRepository implements ClaimRepository {
 
     return {
       data: {
-        isHod: departmentRows.some((row) => row.approver_1 === userId),
-        isFounder: departmentRows.some((row) => row.approver_2 === userId),
+        isHod: departmentRows.some((row) => row.hod_user_id === userId),
+        isFounder: departmentRows.some((row) => row.founder_user_id === userId),
         isFinance: (financeRoleResult.data ?? []).length > 0,
       },
       errorMessage: null,
@@ -1888,7 +1888,7 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const client = getServiceRoleSupabaseClient();
     const { data, error } = await client
       .from("master_departments")
-      .select("approver_1, approver_2")
+      .select("hod_user_id, founder_user_id")
       .eq("id", departmentId)
       .eq("is_active", true)
       .maybeSingle();
@@ -1904,8 +1904,8 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const row = data as DepartmentApproverRoleRow;
     return {
       data: {
-        approver1Id: row.approver_1,
-        approver2Id: row.approver_2,
+        approver1Id: row.hod_user_id,
+        approver2Id: row.founder_user_id,
       },
       errorMessage: null,
     };
@@ -1940,7 +1940,7 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const { data, error } = await client
       .from("master_departments")
       .select("id")
-      .eq("approver_1", userId)
+      .eq("hod_user_id", userId)
       .eq("is_active", true)
       .limit(1);
 

--- a/src/modules/departments/repositories/SupabaseDepartmentRepository.ts
+++ b/src/modules/departments/repositories/SupabaseDepartmentRepository.ts
@@ -15,8 +15,8 @@ type DepartmentJoinRow = {
   id: string;
   name: string;
   is_active: boolean;
-  approver_1: string | null;
-  approver_2: string | null;
+  hod_user_id: string | null;
+  founder_user_id: string | null;
 };
 
 export class SupabaseDepartmentRepository implements DepartmentRepository {
@@ -28,7 +28,7 @@ export class SupabaseDepartmentRepository implements DepartmentRepository {
 
     const { data, error } = await client
       .from("master_departments")
-      .select("id, name, is_active, approver_1, approver_2")
+      .select("id, name, is_active, hod_user_id, founder_user_id")
       .eq("is_active", true)
       .order("name", { ascending: true });
 
@@ -43,7 +43,7 @@ export class SupabaseDepartmentRepository implements DepartmentRepository {
     const approverIds = Array.from(
       new Set(
         rows
-          .flatMap((row) => [row.approver_1, row.approver_2])
+          .flatMap((row) => [row.hod_user_id, row.founder_user_id])
           .filter((id): id is string => Boolean(id)),
       ),
     );
@@ -74,8 +74,10 @@ export class SupabaseDepartmentRepository implements DepartmentRepository {
 
     const mapped = rows
       .map((row) => {
-        const hodUser = row.approver_1 ? (usersById.get(row.approver_1) ?? null) : null;
-        const founderUser = row.approver_2 ? (usersById.get(row.approver_2) ?? null) : null;
+        const hodUser = row.hod_user_id ? (usersById.get(row.hod_user_id) ?? null) : null;
+        const founderUser = row.founder_user_id
+          ? (usersById.get(row.founder_user_id) ?? null)
+          : null;
 
         if (!hodUser || !founderUser) {
           return null;

--- a/supabase/migrations/20260328000100_admin_control_center.sql
+++ b/supabase/migrations/20260328000100_admin_control_center.sql
@@ -1,0 +1,381 @@
+-- ============================================================
+-- Admin Control Center — NxtClaim V2
+-- Adds an orthogonal `admins` table (separate from users.role),
+-- additive RLS policies giving admins system-wide read / write
+-- on master data + soft-delete on claims, and fills the missing
+-- authenticated SELECT policies on master routing tables.
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. public.admins — orthogonal admin membership table
+-- ----------------------------------------------------------------
+create table if not exists public.admins (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references public.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+alter table public.admins enable row level security;
+
+revoke all on table public.admins from anon;
+revoke all on table public.admins from authenticated;
+
+grant select, insert, delete on table public.admins to authenticated;
+
+-- Admins can see the full admins table
+drop policy if exists admins_select_admin on public.admins;
+create policy admins_select_admin
+  on public.admins
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- Admins can add new admins
+drop policy if exists admins_insert_admin on public.admins;
+create policy admins_insert_admin
+  on public.admins
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- Admins can remove admins
+drop policy if exists admins_delete_admin on public.admins;
+create policy admins_delete_admin
+  on public.admins
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 2. Fill missing SELECT policies on master_departments and
+--    master_finance_approvers (RLS is enabled but no SELECT
+--    policies exist, which breaks existing HOD/Finance dropdowns)
+-- ----------------------------------------------------------------
+grant select on table public.master_departments to authenticated;
+
+drop policy if exists master_departments_select_authenticated on public.master_departments;
+create policy master_departments_select_authenticated
+  on public.master_departments
+  for select
+  to authenticated
+  using (true);
+
+grant select on table public.master_finance_approvers to authenticated;
+
+drop policy if exists master_finance_approvers_select_authenticated on public.master_finance_approvers;
+create policy master_finance_approvers_select_authenticated
+  on public.master_finance_approvers
+  for select
+  to authenticated
+  using (true);
+
+-- ----------------------------------------------------------------
+-- 3. Additive RLS policies for admin access on claims
+-- ----------------------------------------------------------------
+grant select, update on table public.claims to authenticated;
+
+drop policy if exists claims_select_admin on public.claims;
+create policy claims_select_admin
+  on public.claims
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists claims_update_admin on public.claims;
+create policy claims_update_admin
+  on public.claims
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 4. Additive RLS policies for admin access on expense_details
+-- ----------------------------------------------------------------
+grant select on table public.expense_details to authenticated;
+
+drop policy if exists expense_details_select_admin on public.expense_details;
+create policy expense_details_select_admin
+  on public.expense_details
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 5. Additive RLS policies for admin access on advance_details
+-- ----------------------------------------------------------------
+grant select on table public.advance_details to authenticated;
+
+drop policy if exists advance_details_select_admin on public.advance_details;
+create policy advance_details_select_admin
+  on public.advance_details
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 6. Extend claim_audit_logs CHECK constraint to include
+--    'ADMIN_SOFT_DELETED' and add INSERT grant for admins
+-- ----------------------------------------------------------------
+alter table public.claim_audit_logs
+  drop constraint if exists claim_audit_logs_action_type_check;
+
+alter table public.claim_audit_logs
+  add constraint claim_audit_logs_action_type_check check (
+    action_type in (
+      'SUBMITTED',
+      'L1_APPROVED',
+      'L1_REJECTED',
+      'L2_APPROVED',
+      'L2_REJECTED',
+      'ADMIN_SOFT_DELETED'
+    )
+  );
+
+grant insert on table public.claim_audit_logs to authenticated;
+
+drop policy if exists claim_audit_logs_insert_admin on public.claim_audit_logs;
+create policy claim_audit_logs_insert_admin
+  on public.claim_audit_logs
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists claim_audit_logs_select_admin on public.claim_audit_logs;
+create policy claim_audit_logs_select_admin
+  on public.claim_audit_logs
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 7. Additive RLS policies for admin on simple master tables
+-- ----------------------------------------------------------------
+grant insert, update on table public.master_expense_categories to authenticated;
+
+drop policy if exists master_expense_categories_insert_admin on public.master_expense_categories;
+create policy master_expense_categories_insert_admin
+  on public.master_expense_categories
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_expense_categories_update_admin on public.master_expense_categories;
+create policy master_expense_categories_update_admin
+  on public.master_expense_categories
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+grant insert, update on table public.master_products to authenticated;
+
+drop policy if exists master_products_insert_admin on public.master_products;
+create policy master_products_insert_admin
+  on public.master_products
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_products_update_admin on public.master_products;
+create policy master_products_update_admin
+  on public.master_products
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+grant insert, update on table public.master_locations to authenticated;
+
+drop policy if exists master_locations_insert_admin on public.master_locations;
+create policy master_locations_insert_admin
+  on public.master_locations
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_locations_update_admin on public.master_locations;
+create policy master_locations_update_admin
+  on public.master_locations
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+grant insert, update on table public.master_payment_modes to authenticated;
+
+drop policy if exists master_payment_modes_insert_admin on public.master_payment_modes;
+create policy master_payment_modes_insert_admin
+  on public.master_payment_modes
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_payment_modes_update_admin on public.master_payment_modes;
+create policy master_payment_modes_update_admin
+  on public.master_payment_modes
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+-- ----------------------------------------------------------------
+-- 8. Additive RLS policies for admin on master_departments (routing)
+-- ----------------------------------------------------------------
+grant insert, update on table public.master_departments to authenticated;
+
+drop policy if exists master_departments_insert_admin on public.master_departments;
+create policy master_departments_insert_admin
+  on public.master_departments
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_departments_update_admin on public.master_departments;
+create policy master_departments_update_admin
+  on public.master_departments
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+-- ----------------------------------------------------------------
+-- 9. Additive RLS policies for admin on master_finance_approvers
+-- ----------------------------------------------------------------
+grant insert, update, delete on table public.master_finance_approvers to authenticated;
+
+drop policy if exists master_finance_approvers_insert_admin on public.master_finance_approvers;
+create policy master_finance_approvers_insert_admin
+  on public.master_finance_approvers
+  for insert
+  to authenticated
+  with check (
+    exists (select 1 from public.admins a where a.user_id = auth.uid())
+  );
+
+drop policy if exists master_finance_approvers_update_admin on public.master_finance_approvers;
+create policy master_finance_approvers_update_admin
+  on public.master_finance_approvers
+  for update
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()))
+  with check (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+drop policy if exists master_finance_approvers_delete_admin on public.master_finance_approvers;
+create policy master_finance_approvers_delete_admin
+  on public.master_finance_approvers
+  for delete
+  to authenticated
+  using (exists (select 1 from public.admins a where a.user_id = auth.uid()));
+
+-- ----------------------------------------------------------------
+-- 10. Additive RLS policies for admin on users
+-- ----------------------------------------------------------------
+grant update on table public.users to authenticated;
+
+drop policy if exists users_select_admin on public.users;
+create policy users_select_admin
+  on public.users
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists users_update_admin on public.users;
+create policy users_update_admin
+  on public.users
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+-- ----------------------------------------------------------------
+-- 11. Additive RLS policies for admin on wallets (read-only)
+-- ----------------------------------------------------------------
+grant select on table public.wallets to authenticated;
+
+drop policy if exists wallets_select_admin on public.wallets;
+create policy wallets_select_admin
+  on public.wallets
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/20260328000200_fix_admins_rls_self_referential_loop.sql
+++ b/supabase/migrations/20260328000200_fix_admins_rls_self_referential_loop.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- Fix: admins table RLS infinite recursion
+-- The original admins_select_admin policy did:
+--   EXISTS (SELECT 1 FROM public.admins WHERE user_id = auth.uid())
+-- which re-triggers the same policy → infinite loop → Postgres
+-- returns 0 rows silently, causing isAdmin() to always return false.
+--
+-- Fix: Replace with a simple column-level check so RLS can be
+-- evaluated without a recursive sub-query.
+-- ============================================================
+
+-- Drop the broken recursive policy
+drop policy if exists admins_select_admin on public.admins;
+
+-- Replace with a non-recursive policy: each user can read their own row
+create policy admins_select_own_row
+  on public.admins
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+-- Also fix INSERT/DELETE policies that share the same recursive pattern
+drop policy if exists admins_insert_admin on public.admins;
+create policy admins_insert_admin
+  on public.admins
+  for insert
+  to authenticated
+  with check (
+    user_id = auth.uid()
+    or exists (
+      select 1 from public.admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists admins_delete_admin on public.admins;
+create policy admins_delete_admin
+  on public.admins
+  for delete
+  to authenticated
+  using (user_id = auth.uid());

--- a/supabase/migrations/20260328000300_fix_schema_drift.sql
+++ b/supabase/migrations/20260328000300_fix_schema_drift.sql
@@ -1,0 +1,179 @@
+-- ============================================================
+-- Fix schema drift between migrations and the hosted database
+--
+-- Issues fixed:
+-- 1. master_departments had approver_1/approver_2 instead of
+--    hod_user_id/founder_user_id (DB state diverged from migrations).
+-- 2. users.role was dropped in schema pivot but the admin UI needs it.
+-- 3. master_finance_approvers gains provisional_email so admins can
+--    pre-register a finance approver by email before they first log in.
+--    When they log in, the auth trigger auto-promotes the provisional
+--    row to a fully-linked row.
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- 1. Rename master_departments columns + FK constraints
+-- ----------------------------------------------------------------
+
+-- Rename approver_1 → hod_user_id
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'master_departments'
+      and column_name = 'approver_1'
+  ) then
+    alter table public.master_departments rename column approver_1 to hod_user_id;
+  end if;
+end $$;
+
+-- Rename approver_2 → founder_user_id
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'master_departments'
+      and column_name = 'approver_2'
+  ) then
+    alter table public.master_departments rename column approver_2 to founder_user_id;
+  end if;
+end $$;
+
+-- Rename FK constraints to match new column names (if old names exist)
+do $$
+begin
+  if exists (
+    select 1 from information_schema.table_constraints
+    where table_schema = 'public'
+      and table_name = 'master_departments'
+      and constraint_name = 'master_departments_approver_1_fkey'
+  ) then
+    alter table public.master_departments
+      rename constraint master_departments_approver_1_fkey
+      to master_departments_hod_user_id_fkey;
+  end if;
+end $$;
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.table_constraints
+    where table_schema = 'public'
+      and table_name = 'master_departments'
+      and constraint_name = 'master_departments_approver_2_fkey'
+  ) then
+    alter table public.master_departments
+      rename constraint master_departments_approver_2_fkey
+      to master_departments_founder_user_id_fkey;
+  end if;
+end $$;
+
+-- Recreate indexes with correct names
+drop index if exists idx_master_departments_hod_user_id;
+drop index if exists idx_master_departments_founder_user_id;
+create index if not exists idx_master_departments_hod_user_id
+  on public.master_departments(hod_user_id);
+create index if not exists idx_master_departments_founder_user_id
+  on public.master_departments(founder_user_id);
+
+-- ----------------------------------------------------------------
+-- 2. Restore users.role (was dropped in schema pivot but required
+--    by the admin Users management tab to assign routing roles)
+-- ----------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'users'
+      and column_name = 'role'
+  ) then
+    alter table public.users
+      add column role text not null default 'employee'
+        check (role in ('employee', 'hod', 'founder', 'finance'));
+  end if;
+end $$;
+
+-- ----------------------------------------------------------------
+-- 3. Provisional finance approver support
+--
+-- Allows an admin to pre-register a finance approver by email.
+-- When that person first logs in, the trigger below auto-promotes
+-- the provisional entry by filling in their user_id.
+-- ----------------------------------------------------------------
+
+-- 3a. Make user_id nullable (was NOT NULL)
+alter table public.master_finance_approvers
+  alter column user_id drop not null;
+
+-- 3b. Add provisional_email column
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'master_finance_approvers'
+      and column_name = 'provisional_email'
+  ) then
+    alter table public.master_finance_approvers
+      add column provisional_email text;
+  end if;
+end $$;
+
+-- 3c. Add constraint: exactly one of user_id or provisional_email must be set
+alter table public.master_finance_approvers
+  drop constraint if exists finance_approver_user_or_email_required;
+
+alter table public.master_finance_approvers
+  add constraint finance_approver_user_or_email_required check (
+    (user_id is not null and provisional_email is null)
+    or
+    (user_id is null and provisional_email is not null)
+  );
+
+-- 3d. Index for the auto-promote trigger lookup
+create index if not exists idx_master_finance_approvers_provisional_email
+  on public.master_finance_approvers(provisional_email)
+  where provisional_email is not null;
+
+-- ----------------------------------------------------------------
+-- 4. Update handle_new_user trigger to auto-promote provisional
+--    finance approver entries when a matching user signs in
+-- ----------------------------------------------------------------
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.email is null then
+    return new;
+  end if;
+
+  -- Upsert user row
+  insert into public.users (id, email, full_name)
+  values (new.id, new.email, new.raw_user_meta_data->>'full_name')
+  on conflict (id) do update
+    set email      = excluded.email,
+        full_name  = coalesce(excluded.full_name, public.users.full_name),
+        updated_at = now();
+
+  -- Upsert wallet row
+  insert into public.wallets (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+
+  -- Promote any provisional finance approver entry that matches this email
+  update public.master_finance_approvers
+  set user_id          = new.id,
+      provisional_email = null,
+      updated_at        = now()
+  where provisional_email = new.email
+    and user_id is null;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260328000400_departments_provisional_actors.sql
+++ b/supabase/migrations/20260328000400_departments_provisional_actors.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- Provisional HOD/Founder support for master_departments
+--
+-- Mirrors the finance approver provisional email pattern.
+-- An admin can enter an email for HOD or Founder. If the user
+-- already exists they are linked immediately. If not, the email
+-- is stored as provisional and the trigger auto-promotes it to
+-- a real user_id when that person first logs in.
+-- ============================================================
+
+-- 1. Make user ID columns nullable (they had NOT NULL previously)
+alter table public.master_departments
+  alter column hod_user_id drop not null;
+
+alter table public.master_departments
+  alter column founder_user_id drop not null;
+
+-- 2. Add provisional email columns
+alter table public.master_departments
+  add column if not exists hod_provisional_email text;
+
+alter table public.master_departments
+  add column if not exists founder_provisional_email text;
+
+-- 3. Enforce: at least one of user_id or provisional_email must be non-null
+alter table public.master_departments
+  drop constraint if exists dept_hod_user_or_email_required;
+
+alter table public.master_departments
+  add constraint dept_hod_user_or_email_required check (
+    hod_user_id is not null or hod_provisional_email is not null
+  );
+
+alter table public.master_departments
+  drop constraint if exists dept_founder_user_or_email_required;
+
+alter table public.master_departments
+  add constraint dept_founder_user_or_email_required check (
+    founder_user_id is not null or founder_provisional_email is not null
+  );
+
+-- 4. Indexes for trigger lookups
+create index if not exists idx_master_departments_hod_provisional_email
+  on public.master_departments(hod_provisional_email)
+  where hod_provisional_email is not null;
+
+create index if not exists idx_master_departments_founder_provisional_email
+  on public.master_departments(founder_provisional_email)
+  where founder_provisional_email is not null;
+
+-- 5. Update handle_new_user trigger to also promote provisional HOD/founder
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.email is null then
+    return new;
+  end if;
+
+  -- Upsert user row
+  insert into public.users (id, email, full_name)
+  values (new.id, new.email, new.raw_user_meta_data->>'full_name')
+  on conflict (id) do update
+    set email      = excluded.email,
+        full_name  = coalesce(excluded.full_name, public.users.full_name),
+        updated_at = now();
+
+  -- Upsert wallet row
+  insert into public.wallets (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+
+  -- Promote provisional finance approver entry
+  update public.master_finance_approvers
+  set user_id           = new.id,
+      provisional_email = null,
+      updated_at        = now()
+  where provisional_email = new.email
+    and user_id is null;
+
+  -- Promote provisional HOD assignment
+  update public.master_departments
+  set hod_user_id           = new.id,
+      hod_provisional_email = null,
+      updated_at            = now()
+  where hod_provisional_email = new.email
+    and hod_user_id is null;
+
+  -- Promote provisional founder assignment
+  update public.master_departments
+  set founder_user_id           = new.id,
+      founder_provisional_email = null,
+      updated_at                = now()
+  where founder_provisional_email = new.email
+    and founder_user_id is null;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260328000500_admins_provisional_email.sql
+++ b/supabase/migrations/20260328000500_admins_provisional_email.sql
@@ -1,0 +1,96 @@
+-- ============================================================
+-- Provisional email support for admins
+--
+-- Mirrors the finance approver provisional email pattern.
+-- An admin can enter an email address for a future admin.
+-- If the user already exists they are linked immediately.
+-- If not, the email is stored as provisional and the trigger
+-- auto-promotes it to a real user_id when that person logs in.
+-- ============================================================
+
+-- 1. Make user_id nullable (previously NOT NULL)
+alter table public.admins
+  alter column user_id drop not null;
+
+-- Add updated_at for trigger bookkeeping
+alter table public.admins
+  add column if not exists updated_at timestamptz not null default now();
+
+-- 2. Add provisional_email column
+alter table public.admins
+  add column if not exists provisional_email text;
+
+-- 3. Enforce: at least one of user_id or provisional_email must be non-null
+alter table public.admins
+  drop constraint if exists admins_user_or_email_required;
+
+alter table public.admins
+  add constraint admins_user_or_email_required check (
+    user_id is not null or provisional_email is not null
+  );
+
+-- 4. Index for trigger lookups
+create index if not exists idx_admins_provisional_email
+  on public.admins(provisional_email)
+  where provisional_email is not null;
+
+-- 5. Update handle_new_user trigger to also promote provisional admins
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.email is null then
+    return new;
+  end if;
+
+  -- Upsert user row
+  insert into public.users (id, email, full_name)
+  values (new.id, new.email, new.raw_user_meta_data->>'full_name')
+  on conflict (id) do update
+    set email      = excluded.email,
+        full_name  = coalesce(excluded.full_name, public.users.full_name),
+        updated_at = now();
+
+  -- Upsert wallet row
+  insert into public.wallets (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+
+  -- Promote provisional finance approver entry
+  update public.master_finance_approvers
+  set user_id           = new.id,
+      provisional_email = null,
+      updated_at        = now()
+  where provisional_email = new.email
+    and user_id is null;
+
+  -- Promote provisional HOD assignment
+  update public.master_departments
+  set hod_user_id           = new.id,
+      hod_provisional_email = null,
+      updated_at            = now()
+  where hod_provisional_email = new.email
+    and hod_user_id is null;
+
+  -- Promote provisional founder assignment
+  update public.master_departments
+  set founder_user_id           = new.id,
+      founder_provisional_email = null,
+      updated_at                = now()
+  where founder_provisional_email = new.email
+    and founder_user_id is null;
+
+  -- Promote provisional admin entry
+  update public.admins
+  set user_id           = new.id,
+      provisional_email = null,
+      updated_at        = now()
+  where provisional_email = new.email
+    and user_id is null;
+
+  return new;
+end;
+$$;

--- a/tests/e2e/bulk-actions-lifecycle.spec.ts
+++ b/tests/e2e/bulk-actions-lifecycle.spec.ts
@@ -20,8 +20,8 @@ type UserRecord = {
 type DepartmentRecord = {
   id: string;
   name: string;
-  approver_1: string;
-  approver_2: string;
+  hod_user_id: string;
+  founder_user_id: string;
 };
 
 type RuntimeActors = {
@@ -104,7 +104,7 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const { data: activeDepartments, error: departmentsError } = await client
     .from("master_departments")
-    .select("id, name, approver_1, approver_2")
+    .select("id, name, hod_user_id, founder_user_id")
     .eq("is_active", true);
 
   if (departmentsError) {
@@ -113,8 +113,8 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const departments = (activeDepartments ?? []) as DepartmentRecord[];
   const submitterDepartment =
-    departments.find((department) => department.approver_1 === hod.id) ??
-    departments.find((department) => department.approver_1 === founder.id) ??
+    departments.find((department) => department.hod_user_id === hod.id) ??
+    departments.find((department) => department.hod_user_id === founder.id) ??
     departments[0];
 
   if (!submitterDepartment) {

--- a/tests/e2e/claims-export-full-data.spec.ts
+++ b/tests/e2e/claims-export-full-data.spec.ts
@@ -77,7 +77,7 @@ async function seedFinanceClaims(seedTag: string): Promise<void> {
         .maybeSingle(),
       client
         .from("master_departments")
-        .select("id, approver_1")
+        .select("id, hod_user_id")
         .eq("is_active", true)
         .limit(1)
         .maybeSingle(),
@@ -87,7 +87,7 @@ async function seedFinanceClaims(seedTag: string): Promise<void> {
     throw new Error(financeUserError?.message ?? "Finance user not found for export seed.");
   }
 
-  if (deptError || !department?.id || !department?.approver_1) {
+  if (deptError || !department?.id || !department?.hod_user_id) {
     throw new Error(deptError?.message ?? "Department routing not found for export seed.");
   }
 
@@ -137,7 +137,7 @@ async function seedFinanceClaims(seedTag: string): Promise<void> {
     cc_emails: "NA",
     department_id: department.id,
     payment_mode_id: paymentMode.id,
-    assigned_l1_approver_id: department.approver_1,
+    assigned_l1_approver_id: department.hod_user_id,
     assigned_l2_approver_id: null,
     submitted_at: new Date(Date.now() - index * 60_000).toISOString(),
     is_active: true,
@@ -243,10 +243,8 @@ test("Finance user can download full CSV containing all form fields", async ({
 
     expect(worksheet.rowCount).toBeGreaterThan(11);
 
-    const headers = worksheet
-      .getRow(1)
-      .values.slice(1)
-      .map((header) => normalizeCellValue(header).trim());
+    const rowValues = worksheet.getRow(1).values as (string | null | undefined)[];
+    const headers = rowValues.slice(1).map((header) => normalizeCellValue(header).trim());
     expect(headers).toEqual([
       "Claim ID",
       "Transaction ID",

--- a/tests/e2e/claims-workflow.spec.ts
+++ b/tests/e2e/claims-workflow.spec.ts
@@ -30,8 +30,8 @@ type UserRecord = {
 type DepartmentRecord = {
   id: string;
   name: string;
-  approver_1: string;
-  approver_2: string;
+  hod_user_id: string;
+  founder_user_id: string;
 };
 
 type FinanceApproverRecord = {
@@ -117,7 +117,7 @@ async function resolveSubmitterDepartment(submitter: UserRecord): Promise<Depart
   const client = getAdminSupabaseClient();
   const { data, error } = await client
     .from("master_departments")
-    .select("id, name, approver_1, approver_2")
+    .select("id, name, hod_user_id, founder_user_id")
     .eq("is_active", true);
 
   if (error) {
@@ -147,13 +147,13 @@ async function resolveSubmitterDepartment(submitter: UserRecord): Promise<Depart
   const latestDepartmentId = latestClaimDepartmentResult.data?.department_id as string | undefined;
   if (latestDepartmentId) {
     const byLatestClaim = departments.find((department) => department.id === latestDepartmentId);
-    if (byLatestClaim && byLatestClaim.approver_1 !== submitter.id) {
+    if (byLatestClaim && byLatestClaim.hod_user_id !== submitter.id) {
       return byLatestClaim;
     }
   }
 
   const nonSelfHodDepartment = departments.find(
-    (department) => department.approver_1 !== submitter.id,
+    (department) => department.hod_user_id !== submitter.id,
   );
   return nonSelfHodDepartment ?? departments[0];
 }
@@ -202,8 +202,8 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const submitterDepartment = await resolveSubmitterDepartment(submitter);
   const lookupUserIds = new Set<string>([
-    submitterDepartment.approver_1,
-    submitterDepartment.approver_2,
+    submitterDepartment.hod_user_id,
+    submitterDepartment.founder_user_id,
   ]);
 
   const client = getAdminSupabaseClient();
@@ -234,9 +234,9 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const departmentsResult = await client
     .from("master_departments")
-    .select("id, name, approver_1, approver_2")
+    .select("id, name, hod_user_id, founder_user_id")
     .eq("is_active", true)
-    .eq("approver_1", knownHod?.id ?? submitterDepartment.approver_1)
+    .eq("hod_user_id", knownHod?.id ?? submitterDepartment.hod_user_id)
     .limit(1)
     .maybeSingle();
 
@@ -244,14 +244,14 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
     throw new Error(`Failed to resolve HOD department: ${departmentsResult.error.message}`);
   }
 
-  const fallbackHodId = knownHod?.id ?? submitterDepartment.approver_1;
+  const fallbackHodId = knownHod?.id ?? submitterDepartment.hod_user_id;
   const hodDepartment = (departmentsResult.data as DepartmentRecord | null) ?? {
     ...submitterDepartment,
-    approver_1: fallbackHodId,
+    hod_user_id: fallbackHodId,
   };
 
-  lookupUserIds.add(hodDepartment.approver_1);
-  lookupUserIds.add(hodDepartment.approver_2);
+  lookupUserIds.add(hodDepartment.hod_user_id);
+  lookupUserIds.add(hodDepartment.founder_user_id);
 
   const usersByIdResult = await client
     .from("users")
@@ -269,8 +269,8 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const effectiveSubmitterDepartment = hodDepartment;
 
-  const submitterHod = usersById.get(effectiveSubmitterDepartment.approver_1);
-  const hodFounder = usersById.get(hodDepartment.approver_2);
+  const submitterHod = usersById.get(effectiveSubmitterDepartment.hod_user_id);
+  const hodFounder = usersById.get(hodDepartment.founder_user_id);
 
   if (!submitterHod || !hodFounder) {
     throw new Error("Unable to resolve HOD/Founder users as active accounts.");
@@ -299,7 +299,7 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const activeDepartmentsResult = await client
     .from("master_departments")
-    .select("id, name, approver_1, approver_2")
+    .select("id, name, hod_user_id, founder_user_id")
     .eq("is_active", true);
 
   if (activeDepartmentsResult.error) {
@@ -310,14 +310,14 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
 
   const activeDepartments = (activeDepartmentsResult.data ?? []) as DepartmentRecord[];
   const founderDepartment =
-    activeDepartments.find((department) => department.approver_2 === hodFounder.id) ?? null;
+    activeDepartments.find((department) => department.founder_user_id === hodFounder.id) ?? null;
 
   const knownApproverIds = new Set([submitterHod.id, hodFounder.id, finance1.id, finance2.id]);
   const crossCandidate =
     activeDepartments
       .filter((department) => department.id !== effectiveSubmitterDepartment.id)
-      .filter((department) => department.approver_1 !== effectiveSubmitterDepartment.approver_1)
-      .find((department) => knownApproverIds.has(department.approver_1)) ?? null;
+      .filter((department) => department.hod_user_id !== effectiveSubmitterDepartment.hod_user_id)
+      .find((department) => knownApproverIds.has(department.hod_user_id)) ?? null;
 
   const crossDepartmentCandidate =
     crossCandidate === null
@@ -325,7 +325,7 @@ async function resolveRuntimeActors(): Promise<RuntimeActors> {
       : {
           department: crossCandidate,
           approverRole: (resolveRoleByUserIdFromKnownUsers(
-            crossCandidate.approver_1,
+            crossCandidate.hod_user_id,
             submitterHod,
             hodFounder,
             finance1,
@@ -1842,7 +1842,7 @@ test.describe("Claims Workflow Multi-Role E2E", () => {
 
     const routing = await getClaimRouting(submitted.claimId);
     expect(routing.departmentId).toBe(candidate.department.id);
-    expect(routing.assignedL1ApproverId).toBe(candidate.department.approver_1);
+    expect(routing.assignedL1ApproverId).toBe(candidate.department.hod_user_id);
 
     await expectClaimVisibleInApprovals(originalHodPage, submitted.claimId, false);
     await expectClaimVisibleInApprovals(targetApproverPage, submitted.claimId, true);

--- a/tests/e2e/lifecycle-wallet-routing.spec.ts
+++ b/tests/e2e/lifecycle-wallet-routing.spec.ts
@@ -112,10 +112,10 @@ async function resolveLeapfrogContext(): Promise<LeapfrogContext> {
 
       const { data: departmentRows, error: departmentError } = await client
         .from("master_departments")
-        .select("id, name, approver_1")
+        .select("id, name, hod_user_id")
         .eq("is_active", true)
-        .eq("approver_2", financeUserId)
-        .neq("approver_1", financeUserId)
+        .eq("founder_user_id", financeUserId)
+        .neq("hod_user_id", financeUserId)
         .order("created_at", { ascending: false })
         .limit(1);
 
@@ -130,7 +130,7 @@ async function resolveLeapfrogContext(): Promise<LeapfrogContext> {
         );
       }
 
-      const hodUserId = department.approver_1;
+      const hodUserId = department.hod_user_id;
       const { data: hodRows, error: hodError } = await client
         .from("users")
         .select("id, email")
@@ -168,10 +168,10 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
 
       const { data: departments, error: departmentsError } = await client
         .from("master_departments")
-        .select("id, name, approver_1, approver_2")
+        .select("id, name, hod_user_id, founder_user_id")
         .eq("is_active", true)
-        .not("approver_1", "is", null)
-        .not("approver_2", "is", null);
+        .not("hod_user_id", "is", null)
+        .not("founder_user_id", "is", null);
 
       if (departmentsError) {
         throw new Error(
@@ -182,13 +182,13 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
       const departmentRows = (departments ?? []) as Array<{
         id: string;
         name: string;
-        approver_1: string;
-        approver_2: string;
+        hod_user_id: string;
+        founder_user_id: string;
       }>;
 
       if (departmentRows.length < 2) {
         throw new Error(
-          "At least two active departments with approver_1 and approver_2 are required for cross-department HOD escalation test.",
+          "At least two active departments with hod_user_id and founder_user_id are required for cross-department HOD escalation test.",
         );
       }
 
@@ -203,13 +203,13 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
       let submitterDepartment =
         preferredSubmitterDepartment &&
         preferredTargetDepartment &&
-        preferredSubmitterDepartment.approver_1 !== preferredTargetDepartment.approver_1
+        preferredSubmitterDepartment.hod_user_id !== preferredTargetDepartment.hod_user_id
           ? preferredSubmitterDepartment
           : null;
       let targetDepartment =
         preferredSubmitterDepartment &&
         preferredTargetDepartment &&
-        preferredSubmitterDepartment.approver_1 !== preferredTargetDepartment.approver_1
+        preferredSubmitterDepartment.hod_user_id !== preferredTargetDepartment.hod_user_id
           ? preferredTargetDepartment
           : null;
 
@@ -218,8 +218,8 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
           const candidate = departmentRows.find(
             (target) =>
               target.id !== source.id &&
-              target.approver_1 !== source.approver_1 &&
-              target.approver_2 !== source.approver_1,
+              target.hod_user_id !== source.hod_user_id &&
+              target.founder_user_id !== source.hod_user_id,
           );
 
           if (candidate) {
@@ -232,14 +232,14 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
 
       if (!submitterDepartment || !targetDepartment) {
         throw new Error(
-          "Unable to resolve two departments where submitter is HOD in one department and target department has a different HOD plus an approver_2.",
+          "Unable to resolve two departments where submitter is HOD in one department and target department has a different HOD plus a founder_user_id.",
         );
       }
 
       const userIds = [
-        submitterDepartment.approver_1,
-        targetDepartment.approver_1,
-        targetDepartment.approver_2,
+        submitterDepartment.hod_user_id,
+        targetDepartment.hod_user_id,
+        targetDepartment.founder_user_id,
       ];
       const uniqueUserIds = [...new Set(userIds)];
 
@@ -256,9 +256,9 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
       }
 
       const emailByUserId = new Map((userRows ?? []).map((row) => [row.id, row.email]));
-      const submitterHodEmail = emailByUserId.get(submitterDepartment.approver_1);
-      const targetHodEmail = emailByUserId.get(targetDepartment.approver_1);
-      const targetApprover2Email = emailByUserId.get(targetDepartment.approver_2);
+      const submitterHodEmail = emailByUserId.get(submitterDepartment.hod_user_id);
+      const targetHodEmail = emailByUserId.get(targetDepartment.hod_user_id);
+      const targetApprover2Email = emailByUserId.get(targetDepartment.founder_user_id);
 
       if (!submitterHodEmail || !targetHodEmail || !targetApprover2Email) {
         throw new Error(
@@ -269,13 +269,13 @@ async function resolveCrossDepartmentHodEscalationContext(): Promise<CrossDepart
       return {
         submitterDepartmentId: submitterDepartment.id,
         submitterDepartmentName: submitterDepartment.name,
-        submitterHodUserId: submitterDepartment.approver_1,
+        submitterHodUserId: submitterDepartment.hod_user_id,
         submitterHodEmail,
         targetDepartmentId: targetDepartment.id,
         targetDepartmentName: targetDepartment.name,
-        targetHodUserId: targetDepartment.approver_1,
+        targetHodUserId: targetDepartment.hod_user_id,
         targetHodEmail,
-        targetApprover2UserId: targetDepartment.approver_2,
+        targetApprover2UserId: targetDepartment.founder_user_id,
         targetApprover2Email,
       };
     })();
@@ -307,10 +307,10 @@ async function resolveProxyFounderContext(): Promise<ProxyFounderContext> {
 
       const { data: departmentRows, error: departmentError } = await client
         .from("master_departments")
-        .select("id, name, approver_1, approver_2")
+        .select("id, name, hod_user_id, founder_user_id")
         .eq("is_active", true)
-        .eq("approver_2", founder.id)
-        .not("approver_1", "is", null)
+        .eq("founder_user_id", founder.id)
+        .not("hod_user_id", "is", null)
         .limit(1);
 
       if (departmentError) {
@@ -318,7 +318,7 @@ async function resolveProxyFounderContext(): Promise<ProxyFounderContext> {
       }
 
       const department = departmentRows?.[0];
-      if (!department?.id || !department?.name || !department?.approver_2) {
+      if (!department?.id || !department?.name || !department?.founder_user_id) {
         throw new Error(
           "No active department found where founder is configured as the senior approver.",
         );
@@ -329,7 +329,7 @@ async function resolveProxyFounderContext(): Promise<ProxyFounderContext> {
         departmentName: department.name,
         founderUserId: founder.id,
         founderEmail: founder.email,
-        seniorApproverUserId: department.approver_2,
+        seniorApproverUserId: department.founder_user_id,
       };
     })();
   }

--- a/tests/e2e/submit-claim.spec.ts
+++ b/tests/e2e/submit-claim.spec.ts
@@ -71,7 +71,7 @@ async function resolveRuntimeFormData(): Promise<RuntimeFormData> {
         .from("master_departments")
         .select("name")
         .eq("is_active", true)
-        .eq("approver_1", hod.id)
+        .eq("hod_user_id", hod.id)
         .order("created_at", { ascending: false })
         .limit(1)
         .maybeSingle();

--- a/tests/unit/admin/AdminSoftDeleteClaimService.test.ts
+++ b/tests/unit/admin/AdminSoftDeleteClaimService.test.ts
@@ -1,0 +1,103 @@
+import { AdminSoftDeleteClaimService } from "@/core/domain/admin/AdminSoftDeleteClaimService";
+import type { AdminRepository } from "@/core/domain/admin/contracts";
+
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function createRepository(overrides?: Partial<AdminRepository>): AdminRepository {
+  return {
+    getAllClaims: jest.fn(),
+    softDeleteClaim: jest.fn(async () => ({ success: true, errorMessage: null })),
+    getMasterDataItems: jest.fn(),
+    createMasterDataItem: jest.fn(),
+    updateMasterDataItem: jest.fn(),
+    getDepartmentsWithActors: jest.fn(),
+    updateDepartmentActors: jest.fn(),
+    updateDepartmentActorsByEmail: jest.fn(),
+    getFinanceApprovers: jest.fn(),
+    createFinanceApprover: jest.fn(),
+    updateFinanceApprover: jest.fn(),
+    getAllUsers: jest.fn(),
+    updateUserRole: jest.fn(),
+    getAdmins: jest.fn(),
+    addAdmin: jest.fn(),
+    removeAdmin: jest.fn(),
+    addFinanceApproverByEmail: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("AdminSoftDeleteClaimService", () => {
+  test("successfully soft-deletes an active claim", async () => {
+    const repository = createRepository();
+    const service = new AdminSoftDeleteClaimService({ repository, logger: createLogger() });
+
+    const result = await service.execute({ claimId: "CLM-001", actorId: "admin-user-1" });
+
+    expect(repository.softDeleteClaim).toHaveBeenCalledWith("CLM-001", "admin-user-1");
+    expect(result.success).toBe(true);
+    expect(result.errorCode).toBeNull();
+    expect(result.errorMessage).toBeNull();
+  });
+
+  test("returns INVALID_INPUT when claimId is empty", async () => {
+    const repository = createRepository();
+    const service = new AdminSoftDeleteClaimService({ repository, logger: createLogger() });
+
+    const result = await service.execute({ claimId: "", actorId: "admin-user-1" });
+
+    expect(repository.softDeleteClaim).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("INVALID_INPUT");
+  });
+
+  test("returns INVALID_INPUT when actorId is empty", async () => {
+    const repository = createRepository();
+    const service = new AdminSoftDeleteClaimService({ repository, logger: createLogger() });
+
+    const result = await service.execute({ claimId: "CLM-001", actorId: "" });
+
+    expect(repository.softDeleteClaim).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("INVALID_INPUT");
+  });
+
+  test("returns DELETE_FAILED when repository returns an error", async () => {
+    const logger = createLogger();
+    const repository = createRepository({
+      softDeleteClaim: jest.fn(async () => ({
+        success: false,
+        errorMessage: "Claim not found",
+      })),
+    });
+    const service = new AdminSoftDeleteClaimService({ repository, logger });
+
+    const result = await service.execute({ claimId: "CLM-999", actorId: "admin-user-1" });
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("SOFT_DELETE_FAILED");
+    expect(result.errorMessage).toBe("Claim not found");
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test("logs a warning but returns success when audit log fails", async () => {
+    const logger = createLogger();
+    const repository = createRepository({
+      softDeleteClaim: jest.fn(async () => ({
+        success: true,
+        errorMessage: "Audit log write failed",
+      })),
+    });
+    const service = new AdminSoftDeleteClaimService({ repository, logger });
+
+    const result = await service.execute({ claimId: "CLM-001", actorId: "admin-user-1" });
+
+    expect(result.success).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin/GetAdminClaimsService.test.ts
+++ b/tests/unit/admin/GetAdminClaimsService.test.ts
@@ -1,0 +1,125 @@
+import { GetAdminClaimsService } from "@/core/domain/admin/GetAdminClaimsService";
+import type { AdminRepository, AdminClaimRecord } from "@/core/domain/admin/contracts";
+
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+const SAMPLE_CLAIM: AdminClaimRecord = {
+  claimId: "CLM-001",
+  employeeName: "Alice",
+  employeeId: "EMP-001",
+  departmentName: "Engineering",
+  typeOfClaim: "Expense",
+  amount: 5000,
+  status: "Submitted - Awaiting HOD approval",
+  submittedOn: "2026-03-14T10:00:00.000Z",
+  hodActionDate: null,
+  financeActionDate: null,
+  detailType: "expense",
+  submissionType: "Self",
+  isActive: true,
+  departmentId: "dept-1",
+};
+
+function createRepository(overrides?: Partial<AdminRepository>): AdminRepository {
+  return {
+    getAllClaims: jest.fn(async () => ({
+      data: { data: [SAMPLE_CLAIM], nextCursor: null, hasNextPage: false },
+      errorMessage: null,
+    })),
+    softDeleteClaim: jest.fn(),
+    getMasterDataItems: jest.fn(),
+    createMasterDataItem: jest.fn(),
+    updateMasterDataItem: jest.fn(),
+    getDepartmentsWithActors: jest.fn(),
+    updateDepartmentActors: jest.fn(),
+    updateDepartmentActorsByEmail: jest.fn(),
+    getFinanceApprovers: jest.fn(),
+    createFinanceApprover: jest.fn(),
+    updateFinanceApprover: jest.fn(),
+    getAllUsers: jest.fn(),
+    updateUserRole: jest.fn(),
+    getAdmins: jest.fn(),
+    addAdmin: jest.fn(),
+    removeAdmin: jest.fn(),
+    addFinanceApproverByEmail: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("GetAdminClaimsService", () => {
+  test("returns paginated claims without user-scoping", async () => {
+    const repository = createRepository();
+    const service = new GetAdminClaimsService({ repository, logger: createLogger() });
+
+    const result = await service.execute({
+      filters: {},
+      pagination: { cursor: null, limit: 10 },
+    });
+
+    expect(repository.getAllClaims).toHaveBeenCalledWith({}, { cursor: null, limit: 10 });
+    expect(result.errorCode).toBeNull();
+    expect(result.errorMessage).toBeNull();
+    expect(result.data?.data).toHaveLength(1);
+    expect(result.data?.data[0].claimId).toBe("CLM-001");
+  });
+
+  test("passes filters to repository", async () => {
+    const repository = createRepository();
+    const service = new GetAdminClaimsService({ repository, logger: createLogger() });
+
+    await service.execute({
+      filters: { departmentId: "dept-1", searchQuery: "alice" },
+      pagination: { cursor: "cursor-1", limit: 5 },
+    });
+
+    expect(repository.getAllClaims).toHaveBeenCalledWith(
+      { departmentId: "dept-1", searchQuery: "alice" },
+      { cursor: "cursor-1", limit: 5 },
+    );
+  });
+
+  test("returns pagination metadata", async () => {
+    const repository = createRepository({
+      getAllClaims: jest.fn(async () => ({
+        data: { data: [SAMPLE_CLAIM], nextCursor: "next-1", hasNextPage: true },
+        errorMessage: null,
+      })),
+    });
+    const service = new GetAdminClaimsService({ repository, logger: createLogger() });
+
+    const result = await service.execute({
+      filters: {},
+      pagination: { cursor: null, limit: 10 },
+    });
+
+    expect(result.data?.hasNextPage).toBe(true);
+    expect(result.data?.nextCursor).toBe("next-1");
+  });
+
+  test("returns FETCH_FAILED error code when repository fails", async () => {
+    const logger = createLogger();
+    const repository = createRepository({
+      getAllClaims: jest.fn(async () => ({
+        data: null,
+        errorMessage: "DB connection failed",
+      })),
+    });
+    const service = new GetAdminClaimsService({ repository, logger });
+
+    const result = await service.execute({
+      filters: {},
+      pagination: { cursor: null, limit: 10 },
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.errorCode).toBe("FETCH_FAILED");
+    expect(result.errorMessage).toBe("DB connection failed");
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin/ManageActorsService.test.ts
+++ b/tests/unit/admin/ManageActorsService.test.ts
@@ -1,0 +1,393 @@
+import { ManageActorsService } from "@/core/domain/admin/ManageActorsService";
+import type {
+  AdminRepository,
+  DepartmentWithActors,
+  FinanceApproverRecord,
+} from "@/core/domain/admin/contracts";
+
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+const SAMPLE_DEPARTMENT: DepartmentWithActors = {
+  id: "dept-1",
+  name: "Engineering",
+  isActive: true,
+  hodUserId: "user-hod-1",
+  hodUserName: "Alice",
+  hodUserEmail: "alice@example.com",
+  hodProvisionalEmail: null,
+  founderUserId: "user-founder-1",
+  founderUserName: "Bob",
+  founderUserEmail: "bob@example.com",
+  founderProvisionalEmail: null,
+};
+
+const SAMPLE_FINANCE_APPROVER: FinanceApproverRecord = {
+  id: "fa-1",
+  userId: "user-finance-1",
+  email: "carol@example.com",
+  fullName: "Carol",
+  isActive: true,
+  isPrimary: true,
+  provisionalEmail: null,
+};
+
+function createRepository(overrides?: Partial<AdminRepository>): AdminRepository {
+  return {
+    getAllClaims: jest.fn(),
+    softDeleteClaim: jest.fn(),
+    getMasterDataItems: jest.fn(),
+    createMasterDataItem: jest.fn(),
+    updateMasterDataItem: jest.fn(),
+    getDepartmentsWithActors: jest.fn(async () => ({
+      data: [SAMPLE_DEPARTMENT],
+      errorMessage: null,
+    })),
+    updateDepartmentActors: jest.fn(async () => ({ success: true, errorMessage: null })),
+    updateDepartmentActorsByEmail: jest.fn(async () => ({ success: true, errorMessage: null })),
+    getFinanceApprovers: jest.fn(async () => ({
+      data: [SAMPLE_FINANCE_APPROVER],
+      errorMessage: null,
+    })),
+    createFinanceApprover: jest.fn(async () => ({
+      data: SAMPLE_FINANCE_APPROVER,
+      errorMessage: null,
+    })),
+    updateFinanceApprover: jest.fn(async () => ({
+      data: { ...SAMPLE_FINANCE_APPROVER },
+      errorMessage: null,
+    })),
+    addFinanceApproverByEmail: jest.fn(async () => ({
+      data: { ...SAMPLE_FINANCE_APPROVER },
+      errorMessage: null,
+    })),
+    getAllUsers: jest.fn(),
+    updateUserRole: jest.fn(),
+    getAdmins: jest.fn(),
+    addAdmin: jest.fn(),
+    removeAdmin: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ManageActorsService", () => {
+  describe("getDepartmentsWithActors", () => {
+    test("returns departments list from repository", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.getDepartmentsWithActors();
+
+      expect(repository.getDepartmentsWithActors).toHaveBeenCalled();
+      expect(result.errorCode).toBeNull();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe("dept-1");
+    });
+
+    test("returns empty array and FETCH_FAILED on repo error", async () => {
+      const repository = createRepository({
+        getDepartmentsWithActors: jest.fn(async () => ({
+          data: [],
+          errorMessage: "DB error",
+        })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.getDepartmentsWithActors();
+
+      expect(result.data).toHaveLength(0);
+      expect(result.errorCode).toBe("FETCH_FAILED");
+      expect(result.errorMessage).toBe("DB error");
+    });
+  });
+
+  describe("updateDepartmentActors", () => {
+    test("calls repo and returns success", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "dept-1",
+        hodUserId: "user-hod-1",
+        founderUserId: "user-founder-1",
+      });
+
+      expect(repository.updateDepartmentActors).toHaveBeenCalledWith(
+        "dept-1",
+        "user-hod-1",
+        "user-founder-1",
+      );
+      expect(result.success).toBe(true);
+      expect(result.errorCode).toBeNull();
+    });
+
+    test("returns INVALID_INPUT for empty departmentId", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "  ",
+        hodUserId: "user-hod-1",
+        founderUserId: "user-founder-1",
+      });
+
+      expect(repository.updateDepartmentActors).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns INVALID_INPUT for empty hodUserId", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "dept-1",
+        hodUserId: "",
+        founderUserId: "user-founder-1",
+      });
+
+      expect(repository.updateDepartmentActors).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns INVALID_INPUT for empty founderUserId", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "dept-1",
+        hodUserId: "user-hod-1",
+        founderUserId: "",
+      });
+
+      expect(repository.updateDepartmentActors).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns SAME_APPROVER when hodUserId equals founderUserId", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "dept-1",
+        hodUserId: "user-1",
+        founderUserId: "user-1",
+      });
+
+      expect(repository.updateDepartmentActors).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("SAME_APPROVER");
+    });
+
+    test("returns UPDATE_FAILED on repo failure", async () => {
+      const repository = createRepository({
+        updateDepartmentActors: jest.fn(async () => ({
+          success: false,
+          errorMessage: "Update conflict",
+        })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActors({
+        departmentId: "dept-1",
+        hodUserId: "user-hod-1",
+        founderUserId: "user-founder-1",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("UPDATE_FAILED");
+      expect(result.errorMessage).toBe("Update conflict");
+    });
+  });
+
+  describe("updateDepartmentActorsByEmail", () => {
+    test("calls repo and returns success", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActorsByEmail({
+        departmentId: "dept-1",
+        hodEmail: "alice@example.com",
+        founderEmail: "bob@example.com",
+      });
+
+      expect(repository.updateDepartmentActorsByEmail).toHaveBeenCalledWith(
+        "dept-1",
+        "alice@example.com",
+        "bob@example.com",
+      );
+      expect(result.success).toBe(true);
+      expect(result.errorCode).toBeNull();
+    });
+
+    test("returns INVALID_INPUT for invalid HOD email", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActorsByEmail({
+        departmentId: "dept-1",
+        hodEmail: "not-an-email",
+        founderEmail: "bob@example.com",
+      });
+
+      expect(repository.updateDepartmentActorsByEmail).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns INVALID_INPUT for invalid Founder email", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActorsByEmail({
+        departmentId: "dept-1",
+        hodEmail: "alice@example.com",
+        founderEmail: "",
+      });
+
+      expect(repository.updateDepartmentActorsByEmail).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns SAME_APPROVER when HOD and Founder emails match", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActorsByEmail({
+        departmentId: "dept-1",
+        hodEmail: "same@example.com",
+        founderEmail: "same@example.com",
+      });
+
+      expect(repository.updateDepartmentActorsByEmail).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("SAME_APPROVER");
+    });
+
+    test("returns UPDATE_FAILED on repo failure", async () => {
+      const repository = createRepository({
+        updateDepartmentActorsByEmail: jest.fn(async () => ({
+          success: false,
+          errorMessage: "DB error",
+        })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateDepartmentActorsByEmail({
+        departmentId: "dept-1",
+        hodEmail: "alice@example.com",
+        founderEmail: "bob@example.com",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("UPDATE_FAILED");
+      expect(result.errorMessage).toBe("DB error");
+    });
+  });
+
+  describe("getFinanceApprovers", () => {
+    test("returns finance approvers list", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.getFinanceApprovers();
+
+      expect(repository.getFinanceApprovers).toHaveBeenCalled();
+      expect(result.errorCode).toBeNull();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe("fa-1");
+    });
+
+    test("returns empty array and FETCH_FAILED on repo error", async () => {
+      const repository = createRepository({
+        getFinanceApprovers: jest.fn(async () => ({
+          data: [],
+          errorMessage: "Finance DB error",
+        })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.getFinanceApprovers();
+
+      expect(result.data).toHaveLength(0);
+      expect(result.errorCode).toBe("FETCH_FAILED");
+    });
+  });
+
+  describe("createFinanceApprover", () => {
+    test("calls repo and returns new record", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.createFinanceApprover({ userId: "user-finance-1" });
+
+      expect(repository.createFinanceApprover).toHaveBeenCalledWith("user-finance-1");
+      expect(result.errorCode).toBeNull();
+      expect(result.data?.userId).toBe("user-finance-1");
+    });
+
+    test("returns INVALID_INPUT for empty userId", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.createFinanceApprover({ userId: "" });
+
+      expect(repository.createFinanceApprover).not.toHaveBeenCalled();
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns CREATE_FAILED on repo error", async () => {
+      const repository = createRepository({
+        createFinanceApprover: jest.fn(async () => ({
+          data: null,
+          errorMessage: "Duplicate user",
+        })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.createFinanceApprover({ userId: "user-finance-1" });
+
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("CREATE_FAILED");
+    });
+  });
+
+  describe("updateFinanceApprover", () => {
+    test("calls repo with payload and returns updated record", async () => {
+      const updated: FinanceApproverRecord = { ...SAMPLE_FINANCE_APPROVER, isActive: false };
+      const repository = createRepository({
+        updateFinanceApprover: jest.fn(async () => ({ data: updated, errorMessage: null })),
+      });
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateFinanceApprover({
+        id: "fa-1",
+        payload: { isActive: false },
+      });
+
+      expect(repository.updateFinanceApprover).toHaveBeenCalledWith("fa-1", { isActive: false });
+      expect(result.errorCode).toBeNull();
+      expect(result.data?.isActive).toBe(false);
+    });
+
+    test("returns INVALID_INPUT for empty id", async () => {
+      const repository = createRepository();
+      const service = new ManageActorsService({ repository, logger: createLogger() });
+
+      const result = await service.updateFinanceApprover({ id: "", payload: { isActive: false } });
+
+      expect(repository.updateFinanceApprover).not.toHaveBeenCalled();
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+  });
+});

--- a/tests/unit/admin/ManageAdminsService.test.ts
+++ b/tests/unit/admin/ManageAdminsService.test.ts
@@ -1,0 +1,203 @@
+import { ManageAdminsService } from "@/core/domain/admin/ManageAdminsService";
+import type {
+  AdminRepository,
+  AdminRecord,
+  AdminUserRecord,
+  AdminCursorPaginatedResult,
+} from "@/core/domain/admin/contracts";
+
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+const SAMPLE_ADMIN: AdminRecord = {
+  id: "admin-rec-1",
+  userId: "user-admin-1",
+  email: "alice@example.com",
+  fullName: "Alice Admin",
+  createdAt: "2026-03-14T10:00:00.000Z",
+};
+
+const SAMPLE_USER: AdminUserRecord = {
+  id: "user-1",
+  fullName: "Bob Employee",
+  email: "bob@example.com",
+  role: "employee",
+  isActive: true,
+  createdAt: "2026-03-14T10:00:00.000Z",
+};
+
+const PAGINATED_USERS: AdminCursorPaginatedResult<AdminUserRecord> = {
+  data: [SAMPLE_USER],
+  nextCursor: null,
+  hasNextPage: false,
+};
+
+function createRepository(overrides?: Partial<AdminRepository>): AdminRepository {
+  return {
+    getAllClaims: jest.fn(),
+    softDeleteClaim: jest.fn(),
+    getMasterDataItems: jest.fn(),
+    createMasterDataItem: jest.fn(),
+    updateMasterDataItem: jest.fn(),
+    getDepartmentsWithActors: jest.fn(),
+    updateDepartmentActors: jest.fn(),
+    updateDepartmentActorsByEmail: jest.fn(),
+    getFinanceApprovers: jest.fn(),
+    createFinanceApprover: jest.fn(),
+    updateFinanceApprover: jest.fn(),
+    addFinanceApproverByEmail: jest.fn(),
+    getAllUsers: jest.fn(async () => ({ data: PAGINATED_USERS, errorMessage: null })),
+    updateUserRole: jest.fn(async () => ({ success: true, errorMessage: null })),
+    getAdmins: jest.fn(async () => ({ data: [SAMPLE_ADMIN], errorMessage: null })),
+    addAdmin: jest.fn(async () => ({ data: SAMPLE_ADMIN, errorMessage: null })),
+    removeAdmin: jest.fn(async () => ({ success: true, errorMessage: null })),
+    ...overrides,
+  };
+}
+
+describe("ManageAdminsService", () => {
+  describe("getAllUsers", () => {
+    test("returns paginated users from repository", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.getAllUsers({ cursor: null, limit: 20 });
+
+      expect(repository.getAllUsers).toHaveBeenCalledWith({ cursor: null, limit: 20 });
+      expect(result.errorCode).toBeNull();
+      expect(result.data?.data).toHaveLength(1);
+      expect(result.data?.data[0].id).toBe("user-1");
+    });
+
+    test("returns null and FETCH_FAILED on repo error", async () => {
+      const repository = createRepository({
+        getAllUsers: jest.fn(async () => ({
+          data: null,
+          errorMessage: "Users fetch failed",
+        })),
+      });
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.getAllUsers({ cursor: null, limit: 20 });
+
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("FETCH_FAILED");
+      expect(result.errorMessage).toBe("Users fetch failed");
+    });
+
+    test("passes cursor to repo for pagination", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      await service.getAllUsers({ cursor: "cursor-abc", limit: 10 });
+
+      expect(repository.getAllUsers).toHaveBeenCalledWith({ cursor: "cursor-abc", limit: 10 });
+    });
+  });
+
+  describe("getAdmins", () => {
+    test("returns admins list from repository", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.getAdmins();
+
+      expect(repository.getAdmins).toHaveBeenCalled();
+      expect(result.errorCode).toBeNull();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe("admin-rec-1");
+    });
+
+    test("returns empty array and FETCH_FAILED on repo error", async () => {
+      const repository = createRepository({
+        getAdmins: jest.fn(async () => ({ data: [], errorMessage: "Admins fetch failed" })),
+      });
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.getAdmins();
+
+      expect(result.data).toHaveLength(0);
+      expect(result.errorCode).toBe("FETCH_FAILED");
+      expect(result.errorMessage).toBe("Admins fetch failed");
+    });
+  });
+
+  describe("addAdmin", () => {
+    test("calls repo and returns new admin record", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.addAdmin("user-admin-1");
+
+      expect(repository.addAdmin).toHaveBeenCalledWith("user-admin-1");
+      expect(result.errorCode).toBeNull();
+      expect(result.data?.userId).toBe("user-admin-1");
+    });
+
+    test("returns INVALID_INPUT for empty userId", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.addAdmin("  ");
+
+      expect(repository.addAdmin).not.toHaveBeenCalled();
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns ADD_FAILED on repo error", async () => {
+      const repository = createRepository({
+        addAdmin: jest.fn(async () => ({ data: null, errorMessage: "Already an admin" })),
+      });
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.addAdmin("user-admin-1");
+
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("ADD_FAILED");
+      expect(result.errorMessage).toBe("Already an admin");
+    });
+  });
+
+  describe("removeAdmin", () => {
+    test("calls repo and returns success", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.removeAdmin("admin-rec-1");
+
+      expect(repository.removeAdmin).toHaveBeenCalledWith("admin-rec-1");
+      expect(result.success).toBe(true);
+      expect(result.errorCode).toBeNull();
+    });
+
+    test("returns INVALID_INPUT for empty adminId", async () => {
+      const repository = createRepository();
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.removeAdmin("");
+
+      expect(repository.removeAdmin).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns REMOVE_FAILED on repo error", async () => {
+      const repository = createRepository({
+        removeAdmin: jest.fn(async () => ({ success: false, errorMessage: "Record not found" })),
+      });
+      const service = new ManageAdminsService({ repository, logger: createLogger() });
+
+      const result = await service.removeAdmin("admin-rec-1");
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("REMOVE_FAILED");
+      expect(result.errorMessage).toBe("Record not found");
+    });
+  });
+});

--- a/tests/unit/admin/ManageMasterDataService.test.ts
+++ b/tests/unit/admin/ManageMasterDataService.test.ts
@@ -1,0 +1,213 @@
+import { ManageMasterDataService } from "@/core/domain/admin/ManageMasterDataService";
+import type { AdminRepository, MasterDataItem } from "@/core/domain/admin/contracts";
+
+function createLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+const SAMPLE_ITEM: MasterDataItem = {
+  id: "item-1",
+  name: "Engineering",
+  isActive: true,
+};
+
+function createRepository(overrides?: Partial<AdminRepository>): AdminRepository {
+  return {
+    getAllClaims: jest.fn(),
+    softDeleteClaim: jest.fn(),
+    getMasterDataItems: jest.fn(async () => ({ data: [SAMPLE_ITEM], errorMessage: null })),
+    createMasterDataItem: jest.fn(async () => ({ data: SAMPLE_ITEM, errorMessage: null })),
+    updateMasterDataItem: jest.fn(async () => ({ data: { ...SAMPLE_ITEM }, errorMessage: null })),
+    getDepartmentsWithActors: jest.fn(),
+    updateDepartmentActors: jest.fn(),
+    updateDepartmentActorsByEmail: jest.fn(),
+    getFinanceApprovers: jest.fn(),
+    createFinanceApprover: jest.fn(),
+    updateFinanceApprover: jest.fn(),
+    getAllUsers: jest.fn(),
+    updateUserRole: jest.fn(),
+    getAdmins: jest.fn(),
+    addAdmin: jest.fn(),
+    removeAdmin: jest.fn(),
+    addFinanceApproverByEmail: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ManageMasterDataService", () => {
+  describe("getItems", () => {
+    test("returns items array for given tableName", async () => {
+      const repository = createRepository();
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.getItems({ tableName: "master_expense_categories" });
+
+      expect(repository.getMasterDataItems).toHaveBeenCalledWith("master_expense_categories");
+      expect(result.errorCode).toBeNull();
+      expect(result.errorMessage).toBeNull();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe("item-1");
+    });
+
+    test("returns empty array and FETCH_FAILED on repo error", async () => {
+      const repository = createRepository({
+        getMasterDataItems: jest.fn(async () => ({
+          data: [],
+          errorMessage: "DB error",
+        })),
+      });
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.getItems({ tableName: "master_expense_categories" });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.errorCode).toBe("FETCH_FAILED");
+      expect(result.errorMessage).toBe("DB error");
+    });
+  });
+
+  describe("createItem", () => {
+    test("creates item with trimmed name", async () => {
+      const repository = createRepository();
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.createItem({
+        tableName: "master_expense_categories",
+        name: "  Finance  ",
+      });
+
+      expect(repository.createMasterDataItem).toHaveBeenCalledWith(
+        "master_expense_categories",
+        "Finance",
+      );
+      expect(result.errorCode).toBeNull();
+      expect(result.data).not.toBeNull();
+    });
+
+    test("returns INVALID_INPUT for empty name", async () => {
+      const repository = createRepository();
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.createItem({
+        tableName: "master_expense_categories",
+        name: "   ",
+      });
+
+      expect(repository.createMasterDataItem).not.toHaveBeenCalled();
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns CREATE_FAILED on repo error", async () => {
+      const repository = createRepository({
+        createMasterDataItem: jest.fn(async () => ({
+          data: null,
+          errorMessage: "Insert failed",
+        })),
+      });
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.createItem({
+        tableName: "master_expense_categories",
+        name: "New Dept",
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("CREATE_FAILED");
+      expect(result.errorMessage).toBe("Insert failed");
+    });
+  });
+
+  describe("updateItem", () => {
+    test("updates name for existing item", async () => {
+      const updated: MasterDataItem = { id: "item-1", name: "Renamed", isActive: true };
+      const repository = createRepository({
+        updateMasterDataItem: jest.fn(async () => ({ data: updated, errorMessage: null })),
+      });
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.updateItem({
+        tableName: "master_expense_categories",
+        id: "item-1",
+        payload: { name: "Renamed" },
+      });
+
+      expect(repository.updateMasterDataItem).toHaveBeenCalledWith(
+        "master_expense_categories",
+        "item-1",
+        { name: "Renamed" },
+      );
+      expect(result.errorCode).toBeNull();
+      expect(result.data?.name).toBe("Renamed");
+    });
+
+    test("updates isActive flag", async () => {
+      const updated: MasterDataItem = { id: "item-1", name: "Engineering", isActive: false };
+      const repository = createRepository({
+        updateMasterDataItem: jest.fn(async () => ({ data: updated, errorMessage: null })),
+      });
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.updateItem({
+        tableName: "master_expense_categories",
+        id: "item-1",
+        payload: { isActive: false },
+      });
+
+      expect(result.data?.isActive).toBe(false);
+      expect(result.errorCode).toBeNull();
+    });
+
+    test("returns INVALID_INPUT for empty id", async () => {
+      const repository = createRepository();
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.updateItem({
+        tableName: "master_expense_categories",
+        id: "   ",
+        payload: { name: "Something" },
+      });
+
+      expect(repository.updateMasterDataItem).not.toHaveBeenCalled();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns INVALID_INPUT when name payload is empty string", async () => {
+      const repository = createRepository();
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.updateItem({
+        tableName: "master_expense_categories",
+        id: "item-1",
+        payload: { name: "  " },
+      });
+
+      expect(repository.updateMasterDataItem).not.toHaveBeenCalled();
+      expect(result.errorCode).toBe("INVALID_INPUT");
+    });
+
+    test("returns UPDATE_FAILED on repo error", async () => {
+      const repository = createRepository({
+        updateMasterDataItem: jest.fn(async () => ({
+          data: null,
+          errorMessage: "Update failed",
+        })),
+      });
+      const service = new ManageMasterDataService({ repository, logger: createLogger() });
+
+      const result = await service.updateItem({
+        tableName: "master_expense_categories",
+        id: "item-1",
+        payload: { isActive: false },
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.errorCode).toBe("UPDATE_FAILED");
+      expect(result.errorMessage).toBe("Update failed");
+    });
+  });
+});


### PR DESCRIPTION
- Implemented provisional email handling for HOD and Founder assignments in master_departments.
- Updated handle_new_user trigger to promote provisional HOD and Founder entries upon user login.
- Added provisional email support for Admins with similar functionality.
- Created unit tests for AdminSoftDeleteClaimService, GetAdminClaimsService, ManageActorsService, ManageAdminsService, and ManageMasterDataService to ensure proper functionality and error handling.
- Enhanced database schema to accommodate new provisional email fields and constraints.