### PR TITLE
feat(claims): add AI metadata tracking for expense claims

### DIFF
--- a/src/app/(dashboard)/dashboard/claims/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/claims/[id]/page.tsx
@@ -525,6 +525,7 @@ async function ClaimDetailCore({
     isAssignedL2Approver ||
     canViewAsFinance ||
     isDepartmentViewerForClaim;
+  const canViewAiMetadata = isFinanceActor || isAdminUser;
   const isPreHodStatus =
     claim.status === DB_SUBMITTED_AWAITING_HOD_APPROVAL_STATUS ||
     claim.status === DB_REJECTED_RESUBMISSION_ALLOWED_STATUS;
@@ -678,6 +679,7 @@ async function ClaimDetailCore({
           claim={claim}
           includeExpenseDetail={false}
           includeAdvanceDetail={false}
+          showAiWarnings={canViewAiMetadata}
         />
 
         {/* ── Supplementary Info ── */}
@@ -744,7 +746,11 @@ async function ClaimDetailCore({
         </section>
       ) : null}
 
-      <ClaimFullDetailsGrid claim={claim} includeSummary={false} />
+      <ClaimFullDetailsGrid
+        claim={claim}
+        includeSummary={false}
+        showAiWarnings={canViewAiMetadata}
+      />
 
       {canTakeDecision ? (
         <section className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-700/50 dark:bg-amber-900/10">

--- a/src/app/(dashboard)/dashboard/my-claims/page.tsx
+++ b/src/app/(dashboard)/dashboard/my-claims/page.tsx
@@ -572,6 +572,16 @@ async function ClaimsCommandCenterTable({
             </>
           ) : (
             <>
+              <MyClaimsPaginationControls
+                hasNextPage={approvalsResult.hasNextPage}
+                currentCursor={cursor}
+                nextCursor={approvalsResult.nextCursor}
+                prevCursor={previousCursorToken}
+                summaryText={approvalsSummaryText}
+                position="top"
+                searchParams={searchParams}
+              />
+
               <Suspense key={JSON.stringify(searchParams ?? {})} fallback={<TableSkeleton />}>
                 <FinanceApprovalsBulkTable
                   claims={rows.map((claim) => ({
@@ -616,15 +626,6 @@ async function ClaimsCommandCenterTable({
                   auditLogsByClaimId={auditLogsByClaimId}
                 />
               </Suspense>
-
-              <MyClaimsPaginationControls
-                hasNextPage={approvalsResult.hasNextPage}
-                currentCursor={cursor}
-                nextCursor={approvalsResult.nextCursor}
-                prevCursor={previousCursorToken}
-                summaryText={approvalsSummaryText}
-                searchParams={searchParams}
-              />
             </>
           )}
         </section>
@@ -668,6 +669,16 @@ async function ClaimsCommandCenterTable({
           </div>
         ) : (
           <>
+            <MyClaimsPaginationControls
+              hasNextPage={approvalsResult.hasNextPage}
+              currentCursor={cursor}
+              nextCursor={approvalsResult.nextCursor}
+              prevCursor={previousCursorToken}
+              summaryText={approvalsSummaryText}
+              position="top"
+              searchParams={searchParams}
+            />
+
             <div className="nxt-scroll w-full overflow-x-auto">
               <table className="min-w-415 divide-y divide-zinc-200/80 text-left text-sm dark:divide-zinc-800">
                 <TableHeader showActions />
@@ -866,15 +877,6 @@ async function ClaimsCommandCenterTable({
                 </tbody>
               </table>
             </div>
-
-            <MyClaimsPaginationControls
-              hasNextPage={approvalsResult.hasNextPage}
-              currentCursor={cursor}
-              nextCursor={approvalsResult.nextCursor}
-              prevCursor={previousCursorToken}
-              summaryText={approvalsSummaryText}
-              searchParams={searchParams}
-            />
           </>
         )}
       </section>
@@ -930,6 +932,16 @@ async function ClaimsCommandCenterTable({
         </div>
       ) : (
         <>
+          <MyClaimsPaginationControls
+            hasNextPage={claimsResult.hasNextPage}
+            currentCursor={cursor}
+            nextCursor={claimsResult.nextCursor}
+            prevCursor={previousCursorToken}
+            summaryText={submissionsSummaryText}
+            position="top"
+            searchParams={searchParams}
+          />
+
           <div className="nxt-scroll overflow-x-auto">
             <table className="min-w-395 divide-y divide-zinc-200/80 text-left text-sm dark:divide-zinc-800">
               <TableHeader showActions />
@@ -1045,15 +1057,6 @@ async function ClaimsCommandCenterTable({
               </tbody>
             </table>
           </div>
-
-          <MyClaimsPaginationControls
-            hasNextPage={claimsResult.hasNextPage}
-            currentCursor={cursor}
-            nextCursor={claimsResult.nextCursor}
-            prevCursor={previousCursorToken}
-            summaryText={submissionsSummaryText}
-            searchParams={searchParams}
-          />
         </>
       )}
     </section>

--- a/src/core/domain/claims/SubmitClaimService.ts
+++ b/src/core/domain/claims/SubmitClaimService.ts
@@ -291,6 +291,7 @@ export class SubmitClaimService {
           bank_statement_file_path: input.expense.bankStatementFilePath,
           people_involved: input.expense.peopleInvolved,
           remarks: input.expense.remarks,
+          ai_metadata: input.expense.aiMetadata,
         };
       }
 

--- a/src/core/domain/claims/contracts.ts
+++ b/src/core/domain/claims/contracts.ts
@@ -26,6 +26,12 @@ export type ClaimDepartmentApprovers = {
   approver2Id: string | null;
 };
 
+export type ClaimExpenseAiOriginalValue = string | number | boolean | null;
+
+export type ClaimExpenseAiMetadata = {
+  edited_fields: Record<string, { original: ClaimExpenseAiOriginalValue }>;
+};
+
 export type ClaimSubmissionInput = {
   submissionType: ClaimSubmissionType;
   detailType: ClaimDetailType;
@@ -60,6 +66,7 @@ export type ClaimSubmissionInput = {
     bankStatementFilePath: string | null;
     peopleInvolved: string | null;
     remarks: string | null;
+    aiMetadata?: ClaimExpenseAiMetadata | null;
   };
   advance?: {
     requestedAmount: number;

--- a/src/modules/admin/repositories/SupabaseAdminRepository.ts
+++ b/src/modules/admin/repositories/SupabaseAdminRepository.ts
@@ -64,8 +64,39 @@ function toEndOfDayIso(date: string): string {
   return `${date}T23:59:59.999Z`;
 }
 
+const POSTGREST_SUBMISSION_TYPE_SELF = '"Self"';
+const POSTGREST_SUBMISSION_TYPE_ON_BEHALF = '"On Behalf"';
+
+function buildBeneficiaryScopedSearchOrFilter(input: {
+  searchQuery: string;
+  selfField: string;
+  onBehalfField: string;
+}): string {
+  return `and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_SELF},${input.selfField}.ilike.%${input.searchQuery}%),and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_ON_BEHALF},${input.onBehalfField}.ilike.%${input.searchQuery}%)`;
+}
+
+function buildEmployeeNameSearchOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "submitter_name_raw",
+    onBehalfField: "beneficiary_name_raw",
+  });
+}
+
+function buildEmployeeEmailSearchOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "submitter_email",
+    onBehalfField: "on_behalf_email",
+  });
+}
+
 function buildEmployeeIdSearchOrFilter(searchQuery: string): string {
-  return `claim_employee_id_raw.ilike.%${searchQuery}%,on_behalf_employee_code_raw.ilike.%${searchQuery}%,submitter_email.ilike.%${searchQuery}%,on_behalf_email.ilike.%${searchQuery}%`;
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "claim_employee_id_raw",
+    onBehalfField: "on_behalf_employee_code_raw",
+  });
 }
 
 const CLAIM_OVERRIDE_REJECTED_STATUSES: readonly DbClaimStatus[] = [
@@ -384,16 +415,16 @@ export class SupabaseAdminRepository implements AdminRepository {
     if (filters.searchQuery) {
       const sq = filters.searchQuery;
       if (filters.searchField === "claim_id") {
-        query = query.eq("claim_id", sq);
+        query = query.ilike("claim_id", `%${sq}%`);
       } else if (filters.searchField === "employee_name") {
-        query = query.ilike("employee_name", `%${sq}%`);
+        query = query.or(buildEmployeeNameSearchOrFilter(sq));
       } else if (filters.searchField === "employee_id") {
         query = query.or(buildEmployeeIdSearchOrFilter(sq));
       } else if (filters.searchField === "employee_email") {
-        query = query.or(`submitter_email.ilike.%${sq}%,on_behalf_email.ilike.%${sq}%`);
+        query = query.or(buildEmployeeEmailSearchOrFilter(sq));
       } else {
         query = query.or(
-          `claim_id.ilike.%${sq}%,employee_name.ilike.%${sq}%,${buildEmployeeIdSearchOrFilter(sq)}`,
+          `claim_id.ilike.%${sq}%,${buildEmployeeNameSearchOrFilter(sq)},${buildEmployeeIdSearchOrFilter(sq)},${buildEmployeeEmailSearchOrFilter(sq)}`,
         );
       }
     }

--- a/src/modules/claims/actions.ts
+++ b/src/modules/claims/actions.ts
@@ -28,6 +28,7 @@ import type {
   ClaimAuditLogRecord,
   ClaimDetailType,
   ClaimDropdownOption,
+  ClaimExpenseAiMetadata,
   FinanceClaimEditPayload,
   GetMyClaimsFilters,
 } from "@/core/domain/claims/contracts";
@@ -177,6 +178,7 @@ export type CurrentUserHydration = {
 export type ClaimQuickViewHydrationData = {
   claim: NonNullable<Awaited<ReturnType<SupabaseClaimRepository["getClaimDetailById"]>>["data"]>;
   auditLogs: (ClaimAuditLogRecord & { formattedCreatedAt: string })[];
+  canViewAiMetadata: boolean;
 };
 
 function classifyDetailType(modeName: string): ClaimDetailType | null {
@@ -278,6 +280,24 @@ function computeExpenseTotalAmount(input: {
 function getFormDataBoolean(input: FormData, key: string): boolean {
   const value = getFormDataString(input, key);
   return value === "true";
+}
+
+function getFormDataJsonObject(input: FormData, key: string): Record<string, unknown> | null {
+  const raw = getFormDataString(input, key).trim();
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }
 
 function isPreHodEditableStatus(status: DbClaimStatus): boolean {
@@ -421,6 +441,7 @@ function extractSubmissionInput(input: unknown): {
       bankStatementFileBase64: getFormDataNullableString(input, "expense.bankStatementFileBase64"),
       peopleInvolved: getFormDataNullableString(input, "expense.peopleInvolved"),
       remarks: getFormDataNullableString(input, "expense.remarks"),
+      aiMetadata: getFormDataJsonObject(input, "expense.aiMetadata"),
     },
     advance: {
       requestedAmount: getFormDataNumber(input, "advance.requestedAmount"),
@@ -636,6 +657,18 @@ export async function getClaimQuickViewHydrationAction(input: {
     };
   }
 
+  const canViewAiMetadata = isFinanceActor || isAdminUser;
+  const hydratedClaim =
+    !canViewAiMetadata && claim.expense
+      ? {
+          ...claim,
+          expense: {
+            ...claim.expense,
+            aiMetadata: null,
+          },
+        }
+      : claim;
+
   const claimAuditLogs = claimAuditLogsResult.errorMessage
     ? []
     : claimAuditLogsResult.data.map((log) => ({
@@ -646,8 +679,9 @@ export async function getClaimQuickViewHydrationAction(input: {
   return {
     ok: true,
     data: {
-      claim,
+      claim: hydratedClaim,
       auditLogs: claimAuditLogs,
+      canViewAiMetadata,
     },
   };
 }
@@ -941,6 +975,7 @@ export async function submitClaimAction(input: unknown): Promise<{
             bankStatementFilePath: uploadedBankStatementFilePath,
             peopleInvolved: parseResult.data.expense.peopleInvolved,
             remarks: parseResult.data.expense.remarks,
+            aiMetadata: parseResult.data.expense.aiMetadata as ClaimExpenseAiMetadata | null,
           }
         : undefined,
     advance:

--- a/src/modules/claims/repositories/SupabaseClaimRepository.ts
+++ b/src/modules/claims/repositories/SupabaseClaimRepository.ts
@@ -65,19 +65,6 @@ type ClaimAdvanceDetailRow = {
   supporting_document_path?: string | null;
 };
 
-type GetMyClaimsRow = {
-  id: string;
-  employee_id: string;
-  on_behalf_email: string | null;
-  submission_type: "Self" | "On Behalf";
-  status: DbClaimStatus;
-  submitted_at: string;
-  master_departments: ClaimRelationNameRow | ClaimRelationNameRow[] | null;
-  master_payment_modes: ClaimRelationNameRow | ClaimRelationNameRow[] | null;
-  expense_details: ClaimExpenseDetailRow | ClaimExpenseDetailRow[] | null;
-  advance_details: ClaimAdvanceDetailRow | ClaimAdvanceDetailRow[] | null;
-};
-
 type EnterpriseClaimsDashboardRow = {
   claim_id: string;
   employee_name: string;
@@ -143,25 +130,6 @@ type DepartmentApproverRoleRow = {
 type UserLookupRow = {
   id: string;
   is_active: boolean;
-};
-
-type GetPendingApprovalsRow = {
-  id: string;
-  employee_id: string;
-  detail_type: "expense" | "advance";
-  submission_type: "Self" | "On Behalf";
-  on_behalf_email: string | null;
-  on_behalf_employee_code: string | null;
-  status: DbClaimStatus;
-  submitted_at: string;
-  created_at: string;
-  hod_action_at: string | null;
-  finance_action_at: string | null;
-  submitter_user: ClaimSubmitterRow | ClaimSubmitterRow[] | null;
-  master_departments: ClaimRelationNameRow | ClaimRelationNameRow[] | null;
-  master_payment_modes: ClaimRelationNameRow | ClaimRelationNameRow[] | null;
-  expense_details: ClaimExpenseDetailRow | ClaimExpenseDetailRow[] | null;
-  advance_details: ClaimAdvanceDetailRow | ClaimAdvanceDetailRow[] | null;
 };
 
 type ClaimL1DecisionRow = {
@@ -505,7 +473,8 @@ const EXPORT_WALLET_LOOKUP_BATCH_SIZE = 200;
 const MAX_LIST_PAGE_SIZE = 50;
 const UNIQUE_VIOLATION_CODE = "23505";
 const DUPLICATE_ACTIVE_EXPENSE_BILL_CONSTRAINT = "uq_expense_details_active_bill";
-const POSTGREST_NEVER_MATCH_UUID = "00000000-0000-0000-0000-000000000000";
+const POSTGREST_SUBMISSION_TYPE_SELF = '"Self"';
+const POSTGREST_SUBMISSION_TYPE_ON_BEHALF = '"On Behalf"';
 
 function chunkArray<T>(values: T[], chunkSize: number): T[][] {
   if (chunkSize <= 0) {
@@ -531,42 +500,6 @@ function clampListPageSize(limit: number): number {
 
 function toPostgrestInList(values: string[]): string {
   return `(${values.map((value) => `"${value.replace(/"/g, '\\"')}"`).join(",")})`;
-}
-
-function getNeverMatchUserIdFilter(): string {
-  return toPostgrestInList([POSTGREST_NEVER_MATCH_UUID]);
-}
-
-async function resolveSubmitterUserIdsFilter(input: {
-  client: ReturnType<typeof getServiceRoleSupabaseClient>;
-  searchQuery: string;
-}): Promise<{ data: string; errorMessage: string | null }> {
-  const { data, error } = await input.client
-    .from("users")
-    .select("id")
-    .ilike("email", `%${input.searchQuery}%`)
-    .limit(MAX_LIST_PAGE_SIZE);
-
-  if (error) {
-    return {
-      data: getNeverMatchUserIdFilter(),
-      errorMessage: error.message,
-    };
-  }
-
-  const ids = [...new Set((data ?? []).map((row) => String(row.id)).filter((id) => id.length > 0))];
-
-  if (ids.length === 0) {
-    return {
-      data: getNeverMatchUserIdFilter(),
-      errorMessage: null,
-    };
-  }
-
-  return {
-    data: toPostgrestInList(ids),
-    errorMessage: null,
-  };
 }
 
 function containsDuplicateExpenseBillConstraint(value: string | null | undefined): boolean {
@@ -655,19 +588,36 @@ function normalizeSearchInput(filters?: GetMyClaimsFilters): {
   };
 }
 
-function buildEmployeeEmailOrFilter(searchQuery: string, submitterEmailColumn: string): string {
-  return `${submitterEmailColumn}.ilike.%${searchQuery}%,on_behalf_email.ilike.%${searchQuery}%`;
+function buildBeneficiaryScopedOrFilter(input: {
+  searchQuery: string;
+  selfField: string;
+  onBehalfField: string;
+}): string {
+  return `and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_SELF},${input.selfField}.ilike.%${input.searchQuery}%),and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_ON_BEHALF},${input.onBehalfField}.ilike.%${input.searchQuery}%)`;
 }
 
-function buildPendingApprovalsEmployeeEmailOrFilter(
-  searchQuery: string,
-  submitterUserIdsFilter: string,
-): string {
-  return `submitted_by.in.${submitterUserIdsFilter},on_behalf_email.ilike.%${searchQuery}%`;
+function buildEmployeeNameOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedOrFilter({
+    searchQuery,
+    selfField: "submitter_name_raw",
+    onBehalfField: "beneficiary_name_raw",
+  });
 }
 
-function buildEnterpriseEmployeeIdOrFilter(searchQuery: string): string {
-  return `claim_employee_id_raw.ilike.%${searchQuery}%,on_behalf_employee_code_raw.ilike.%${searchQuery}%,submitter_email.ilike.%${searchQuery}%,on_behalf_email.ilike.%${searchQuery}%`;
+function buildEmployeeEmailOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedOrFilter({
+    searchQuery,
+    selfField: "submitter_email",
+    onBehalfField: "on_behalf_email",
+  });
+}
+
+function buildEmployeeIdOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedOrFilter({
+    searchQuery,
+    selfField: "claim_employee_id_raw",
+    onBehalfField: "on_behalf_employee_code_raw",
+  });
 }
 
 function resolveEnterpriseDateColumn(dateTarget?: ClaimDateTarget): string {
@@ -678,11 +628,10 @@ function resolveEnterpriseDateColumn(dateTarget?: ClaimDateTarget): string {
 
 function resolvePendingApprovalsDateColumn(
   dateTarget?: ClaimDateTarget,
-  defaultColumn: string = "submitted_at",
+  defaultColumn: string = "submitted_on",
 ): string {
-  if (dateTarget === "hod_action") return "hod_action_at";
-  // Use the dedicated finance_action_at column rather than the generic updated_at proxy.
-  if (dateTarget === "finance_closed") return "finance_action_at";
+  if (dateTarget === "hod_action") return "hod_action_date";
+  if (dateTarget === "finance_closed") return "finance_action_date";
   return defaultColumn;
 }
 
@@ -794,17 +743,15 @@ function applyEnterpriseDashboardFilters<
     }
 
     if (params.normalizedSearch.field === "employee_name") {
-      query = query.ilike("employee_name", `%${params.normalizedSearch.query}%`);
+      query = query.or(buildEmployeeNameOrFilter(params.normalizedSearch.query));
     }
 
     if (params.normalizedSearch.field === "employee_id") {
-      query = query.or(buildEnterpriseEmployeeIdOrFilter(params.normalizedSearch.query));
+      query = query.or(buildEmployeeIdOrFilter(params.normalizedSearch.query));
     }
 
     if (params.normalizedSearch.field === "employee_email") {
-      query = query.or(
-        buildEmployeeEmailOrFilter(params.normalizedSearch.query, "submitter_email"),
-      );
+      query = query.or(buildEmployeeEmailOrFilter(params.normalizedSearch.query));
     }
   }
 
@@ -829,7 +776,6 @@ function applyPendingApprovalsFilters<TQuery extends PendingApprovalsQueryChain<
   toDate?: string;
   dateColumn: string;
   normalizedSearch: { field: GetMyClaimsFilters["searchField"]; query: string };
-  submitterUserIdsFilter: string;
 }): TQuery {
   let { query } = params;
 
@@ -837,9 +783,9 @@ function applyPendingApprovalsFilters<TQuery extends PendingApprovalsQueryChain<
     ["detail_type", params.filters?.detailType],
     ["payment_mode_id", params.filters?.paymentModeId],
     ["department_id", params.filters?.departmentId],
-    ["expense_details.location_id", params.filters?.locationId],
-    ["expense_details.product_id", params.filters?.productId],
-    ["expense_details.expense_category_id", params.filters?.expenseCategoryId],
+    ["location_id", params.filters?.locationId],
+    ["product_id", params.filters?.productId],
+    ["expense_category_id", params.filters?.expenseCategoryId],
     ["submission_type", params.filters?.submissionType],
   ];
 
@@ -861,110 +807,96 @@ function applyPendingApprovalsFilters<TQuery extends PendingApprovalsQueryChain<
   }
 
   if (params.filters?.dateTarget === "hod_action") {
-    query = query.not("hod_action_at", "is", null);
+    query = query.not("hod_action_date", "is", null);
   }
 
   if (hasAdvancedEnterpriseDateFilters(params.filters)) {
     if (params.filters?.submittedFrom) {
-      query = query.gte("submitted_at", toStartOfDayIso(params.filters.submittedFrom));
+      query = query.gte("submitted_on", toStartOfDayIso(params.filters.submittedFrom));
     }
 
     if (params.filters?.submittedTo) {
-      query = query.lte("submitted_at", toEndOfDayIso(params.filters.submittedTo));
+      query = query.lte("submitted_on", toEndOfDayIso(params.filters.submittedTo));
     }
 
     if (params.filters?.hodActionFrom) {
-      query = query.gte("hod_action_at", toStartOfDayIso(params.filters.hodActionFrom));
+      query = query.gte("hod_action_date", toStartOfDayIso(params.filters.hodActionFrom));
     }
 
     if (params.filters?.hodActionTo) {
-      query = query.lte("hod_action_at", toEndOfDayIso(params.filters.hodActionTo));
+      query = query.lte("hod_action_date", toEndOfDayIso(params.filters.hodActionTo));
     }
 
     if (params.filters?.financeActionFrom) {
-      query = query.gte("finance_action_at", toStartOfDayIso(params.filters.financeActionFrom));
+      query = query.gte("finance_action_date", toStartOfDayIso(params.filters.financeActionFrom));
     }
 
     if (params.filters?.financeActionTo) {
-      query = query.lte("finance_action_at", toEndOfDayIso(params.filters.financeActionTo));
+      query = query.lte("finance_action_date", toEndOfDayIso(params.filters.financeActionTo));
     }
   } else {
     if (params.fromDate) {
-      query = query.gte(params.dateColumn, `${params.fromDate}T00:00:00.000Z`);
+      query = query.gte(params.dateColumn, toStartOfDayIso(params.fromDate));
     }
 
     if (params.toDate) {
-      query = query.lte(params.dateColumn, `${params.toDate}T23:59:59.999Z`);
+      query = query.lte(params.dateColumn, toEndOfDayIso(params.toDate));
     }
   }
 
   if (params.normalizedSearch.query && params.normalizedSearch.field) {
     if (params.normalizedSearch.field === "claim_id") {
-      query = query.ilike("id", `%${params.normalizedSearch.query}%`);
+      query = query.ilike("claim_id", `%${params.normalizedSearch.query}%`);
     }
 
     if (params.normalizedSearch.field === "employee_name") {
-      query = query.ilike("submitter_user.full_name", `%${params.normalizedSearch.query}%`);
+      query = query.or(buildEmployeeNameOrFilter(params.normalizedSearch.query));
     }
 
     if (params.normalizedSearch.field === "employee_id") {
-      query = query.ilike("employee_id", `%${params.normalizedSearch.query}%`);
+      query = query.or(buildEmployeeIdOrFilter(params.normalizedSearch.query));
     }
 
     if (params.normalizedSearch.field === "employee_email") {
-      query = query.or(
-        buildPendingApprovalsEmployeeEmailOrFilter(
-          params.normalizedSearch.query,
-          params.submitterUserIdsFilter,
-        ),
-      );
+      query = query.or(buildEmployeeEmailOrFilter(params.normalizedSearch.query));
     }
   }
 
   return query;
 }
 
-function mapPendingApprovalRows(rows: GetPendingApprovalsRow[]) {
+function mapPendingApprovalRows(rows: EnterpriseClaimsDashboardRow[]) {
   return rows.map((row) => {
-    const department = getSingleRelation(row.master_departments);
-    const paymentMode = getSingleRelation(row.master_payment_modes);
-    const expense = getSingleRelation(row.expense_details);
-    const advance = getSingleRelation(row.advance_details);
-    const expenseCategory = getSingleRelation(expense?.master_expense_categories);
-    const submitter = getSingleRelation(row.submitter_user);
-    const submitterName = submitter?.full_name?.trim();
-    const submitterEmail = submitter?.email?.trim();
     const submitterLabel =
-      submitterName && submitterEmail
-        ? `${submitterName} (${submitterEmail})`
-        : (submitterName ?? submitterEmail ?? row.employee_id);
+      row.submitter_label?.trim() || row.submitter_email?.trim() || row.employee_id;
+    const amount = toNumber(row.amount) ?? 0;
 
     return {
-      id: row.id,
+      id: row.claim_id,
       employeeId: row.employee_id,
       submitter: submitterLabel,
-      submitterEmail: submitterEmail ?? null,
-      departmentName: department?.name ?? null,
-      paymentModeName: paymentMode?.name ?? "Unknown Payment Mode",
+      submitterEmail: row.submitter_email ?? null,
+      departmentName: row.department_name ?? null,
+      paymentModeName: row.type_of_claim || "Unknown Payment Mode",
       detailType: row.detail_type,
       submissionType: row.submission_type,
-      onBehalfEmail: row.on_behalf_email,
-      onBehalfEmployeeCode: row.on_behalf_employee_code,
-      purpose: expense?.purpose ?? advance?.purpose ?? null,
+      onBehalfEmail: row.on_behalf_email ?? null,
+      onBehalfEmployeeCode: row.on_behalf_employee_code_raw ?? null,
+      purpose: row.purpose ?? null,
       categoryName:
-        row.detail_type === "expense" ? (expenseCategory?.name ?? "Uncategorized") : "Advance",
+        row.detail_type === "expense" ? (row.category_name ?? "Uncategorized") : "Advance",
       evidenceFilePath:
         row.detail_type === "expense"
-          ? (expense?.receipt_file_path ?? null)
-          : (advance?.supporting_document_path ?? null),
-      expenseReceiptFilePath: expense?.receipt_file_path ?? null,
-      expenseBankStatementFilePath: expense?.bank_statement_file_path ?? null,
-      advanceSupportingDocumentPath: advance?.supporting_document_path ?? null,
-      totalAmount: toNumber(expense?.total_amount) ?? toNumber(advance?.requested_amount) ?? 0,
+          ? (row.receipt_file_path ?? null)
+          : (row.supporting_document_path ?? null),
+      expenseReceiptFilePath: row.receipt_file_path ?? null,
+      expenseBankStatementFilePath: row.bank_statement_file_path ?? null,
+      advanceSupportingDocumentPath: row.supporting_document_path ?? null,
+      totalAmount: amount,
       status: row.status,
-      submittedAt: row.submitted_at,
-      hodActionAt: row.hod_action_at ?? null,
-      financeActionAt: row.finance_action_at ?? null,
+      submittedAt: row.submitted_on,
+      hodActionAt: row.hod_action_date ?? null,
+      financeActionAt: row.finance_action_date ?? null,
     };
   });
 }
@@ -1352,92 +1284,37 @@ export class SupabaseClaimRepository implements ClaimRepository {
     filters?: GetMyClaimsFilters,
   ): Promise<{ count: number; errorMessage: string | null }> {
     const client = getServiceRoleSupabaseClient();
-    const normalizedStatuses = normalizeStatusFilter(filters?.status);
+    const normalizedStatuses = normalizeStatusFilter(filters?.status).filter((status) =>
+      L1_ACTIONABLE_STATUSES.includes(status),
+    );
     const { fromDate, toDate } = normalizeDateRange(filters);
-    const dateColumn = resolvePendingApprovalsDateColumn(filters?.dateTarget);
     const normalizedSearch = normalizeSearchInput(filters);
 
     if (filters?.dateTarget === "finance_closed") {
       return { count: 0, errorMessage: null };
     }
 
+    if (filters?.status && normalizedStatuses.length === 0) {
+      return { count: 0, errorMessage: null };
+    }
+
     let query = client
-      .from("claims")
-      .select("id, submitter_user:users!claims_submitted_by_fkey!inner(full_name, email)", {
+      .from("vw_enterprise_claims_dashboard")
+      .select("claim_id", {
         count: "exact",
         head: true,
       })
       .eq("assigned_l1_approver_id", userId)
-      .eq("is_active", true)
       .in("status", L1_ACTIONABLE_STATUSES);
 
-    if (filters?.detailType) {
-      query = query.eq("detail_type", filters.detailType);
-    }
-
-    if (filters?.paymentModeId) {
-      query = query.eq("payment_mode_id", filters.paymentModeId);
-    }
-
-    if (filters?.departmentId) {
-      query = query.eq("department_id", filters.departmentId);
-    }
-
-    if (filters?.submissionType) {
-      query = query.eq("submission_type", filters.submissionType);
-    }
-
-    if (normalizedStatuses.length > 0) {
-      const actionableStatuses = normalizedStatuses.filter((status) =>
-        L1_ACTIONABLE_STATUSES.includes(status),
-      );
-
-      if (actionableStatuses.length === 0) {
-        return { count: 0, errorMessage: null };
-      }
-
-      query = query.in("status", actionableStatuses);
-    }
-
-    if (fromDate) {
-      query = query.gte(dateColumn, `${fromDate}T00:00:00.000Z`);
-    }
-
-    if (toDate) {
-      query = query.lte(dateColumn, `${toDate}T23:59:59.999Z`);
-    }
-
-    if (normalizedSearch.query && normalizedSearch.field) {
-      if (normalizedSearch.field === "claim_id") {
-        query = query.eq("id", normalizedSearch.query);
-      }
-
-      if (normalizedSearch.field === "employee_name") {
-        query = query.ilike("submitter_user.full_name", `%${normalizedSearch.query}%`);
-      }
-
-      if (normalizedSearch.field === "employee_id") {
-        query = query.ilike("employee_id", `%${normalizedSearch.query}%`);
-      }
-
-      if (normalizedSearch.field === "employee_email") {
-        const submitterUserIdsFilterResult = await resolveSubmitterUserIdsFilter({
-          client,
-          searchQuery: normalizedSearch.query,
-        });
-
-        if (submitterUserIdsFilterResult.errorMessage) {
-          return { count: 0, errorMessage: submitterUserIdsFilterResult.errorMessage };
-        }
-
-        query = query.or(
-          buildPendingApprovalsEmployeeEmailOrFilter(
-            normalizedSearch.query,
-            submitterUserIdsFilterResult.data,
-          ),
-        );
-      }
-    }
+    query = applyEnterpriseDashboardFilters({
+      query,
+      filters,
+      normalizedStatuses,
+      fromDate,
+      toDate,
+      normalizedSearch,
+    });
 
     const { count, error } = await query;
 
@@ -2761,101 +2638,25 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const client = getServiceRoleSupabaseClient();
     const normalizedStatuses = normalizeStatusFilter(filters?.status);
     const { fromDate, toDate } = normalizeDateRange(filters);
-    const dateColumn = resolvePendingApprovalsDateColumn(filters?.dateTarget);
     const normalizedSearch = normalizeSearchInput(filters);
 
-    const needsExpenseInnerJoin =
-      filters?.locationId || filters?.productId || filters?.expenseCategoryId;
-
-    const expenseDetailsJoin = needsExpenseInnerJoin
-      ? "expense_details!inner(total_amount, location_id, product_id, expense_category_id)"
-      : "expense_details(total_amount)";
-
     let query = client
-      .from("claims")
+      .from("vw_enterprise_claims_dashboard")
       .select(
-        `id, employee_id, on_behalf_email, submission_type, status, submitted_at, updated_at, submitter_user:users!claims_submitted_by_fkey!inner(full_name, email), master_departments(name), master_payment_modes(name), ${expenseDetailsJoin}, advance_details(requested_amount)`,
+        "claim_id, employee_id, on_behalf_email, submission_type, status, submitted_on, detail_type, amount, department_name, type_of_claim, submitted_by, on_behalf_of_id",
       )
       .or(buildMyClaimsOwnershipOrFilter(userId))
-      .eq("is_active", true)
-      .order("submitted_at", { ascending: false })
+      .order("submitted_on", { ascending: false })
       .limit(MAX_LIST_PAGE_SIZE);
 
-    if (filters?.detailType) {
-      query = query.eq("detail_type", filters.detailType);
-    }
-
-    if (filters?.paymentModeId) {
-      query = query.eq("payment_mode_id", filters.paymentModeId);
-    }
-
-    if (filters?.departmentId) {
-      query = query.eq("department_id", filters.departmentId);
-    }
-
-    if (filters?.locationId) {
-      query = query.eq("expense_details.location_id", filters.locationId);
-    }
-
-    if (filters?.productId) {
-      query = query.eq("expense_details.product_id", filters.productId);
-    }
-
-    if (filters?.expenseCategoryId) {
-      query = query.eq("expense_details.expense_category_id", filters.expenseCategoryId);
-    }
-
-    if (filters?.submissionType) {
-      query = query.eq("submission_type", filters.submissionType);
-    }
-
-    if (normalizedStatuses.length > 0) {
-      query = query.in("status", normalizedStatuses);
-    }
-
-    if (filters?.dateTarget === "finance_closed") {
-      query = query.in("status", FINANCE_CLOSED_STATUSES);
-    }
-
-    if (fromDate) {
-      query = query.gte(dateColumn, `${fromDate}T00:00:00.000Z`);
-    }
-
-    if (toDate) {
-      query = query.lte(dateColumn, `${toDate}T23:59:59.999Z`);
-    }
-
-    if (normalizedSearch.query && normalizedSearch.field) {
-      if (normalizedSearch.field === "claim_id") {
-        query = query.eq("id", normalizedSearch.query);
-      }
-
-      if (normalizedSearch.field === "employee_name") {
-        query = query.ilike("submitter_user.full_name", `%${normalizedSearch.query}%`);
-      }
-
-      if (normalizedSearch.field === "employee_id") {
-        query = query.ilike("employee_id", `%${normalizedSearch.query}%`);
-      }
-
-      if (normalizedSearch.field === "employee_email") {
-        const submitterUserIdsFilterResult = await resolveSubmitterUserIdsFilter({
-          client,
-          searchQuery: normalizedSearch.query,
-        });
-
-        if (submitterUserIdsFilterResult.errorMessage) {
-          return { data: [], errorMessage: submitterUserIdsFilterResult.errorMessage };
-        }
-
-        query = query.or(
-          buildPendingApprovalsEmployeeEmailOrFilter(
-            normalizedSearch.query,
-            submitterUserIdsFilterResult.data,
-          ),
-        );
-      }
-    }
+    query = applyEnterpriseDashboardFilters({
+      query,
+      filters,
+      normalizedStatuses,
+      fromDate,
+      toDate,
+      normalizedSearch,
+    });
 
     const { data, error } = await query;
 
@@ -2863,25 +2664,22 @@ export class SupabaseClaimRepository implements ClaimRepository {
       return { data: [], errorMessage: error.message };
     }
 
-    const rows = (data ?? []) as GetMyClaimsRow[];
+    const rows = (data ?? []) as EnterpriseClaimsDashboardRow[];
     return {
       data: rows.map((row) => {
-        const department = getSingleRelation(row.master_departments);
-        const paymentMode = getSingleRelation(row.master_payment_modes);
-        const expense = getSingleRelation(row.expense_details);
-        const advance = getSingleRelation(row.advance_details);
+        const amount = toNumber(row.amount);
 
         return {
-          id: row.id,
+          id: row.claim_id,
           employeeId: row.employee_id,
-          onBehalfEmail: row.on_behalf_email,
-          departmentName: department?.name ?? null,
-          paymentModeName: paymentMode?.name ?? "Unknown Payment Mode",
+          onBehalfEmail: row.on_behalf_email ?? null,
+          departmentName: row.department_name ?? null,
+          paymentModeName: row.type_of_claim || "Unknown Payment Mode",
           submissionType: row.submission_type,
           status: row.status,
-          submittedAt: row.submitted_at,
-          expenseTotalAmount: toNumber(expense?.total_amount),
-          advanceRequestedAmount: toNumber(advance?.requested_amount),
+          submittedAt: row.submitted_on,
+          expenseTotalAmount: row.detail_type === "expense" ? amount : null,
+          advanceRequestedAmount: row.detail_type === "advance" ? amount : null,
         };
       }),
       errorMessage: null,
@@ -3060,9 +2858,9 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const decodedCursor = decodeClaimsCursor(cursor);
     const normalizedStatuses = normalizeStatusFilter(filters?.status);
     const { fromDate, toDate } = normalizeDateRange(filters);
-    // Default to hod_action_at so date-range filters reflect when the L1 approver acted,
+    // Default to hod_action_date so date-range filters reflect when the L1 approver acted,
     // not when the submitter originally submitted the claim.
-    const dateColumn = resolvePendingApprovalsDateColumn(filters?.dateTarget, "hod_action_at");
+    const dateColumn = resolvePendingApprovalsDateColumn(filters?.dateTarget, "hod_action_date");
     const normalizedSearch = normalizeSearchInput(filters);
     const safeLimit = clampListPageSize(limit);
 
@@ -3076,44 +2874,15 @@ export class SupabaseClaimRepository implements ClaimRepository {
       };
     }
 
-    let submitterUserIdsFilter = getNeverMatchUserIdFilter();
-
-    if (normalizedSearch.query && normalizedSearch.field === "employee_email") {
-      const submitterUserIdsFilterResult = await resolveSubmitterUserIdsFilter({
-        client,
-        searchQuery: normalizedSearch.query,
-      });
-
-      if (submitterUserIdsFilterResult.errorMessage) {
-        return {
-          data: [],
-          nextCursor: null,
-          hasNextPage: false,
-          totalCount: 0,
-          errorMessage: submitterUserIdsFilterResult.errorMessage,
-        };
-      }
-
-      submitterUserIdsFilter = submitterUserIdsFilterResult.data;
-    }
-
-    const needsExpenseInnerJoin =
-      filters?.locationId || filters?.productId || filters?.expenseCategoryId;
-
-    const expenseDetailsJoin = needsExpenseInnerJoin
-      ? "expense_details!inner(total_amount, purpose, receipt_file_path, bank_statement_file_path, master_expense_categories(name), location_id, product_id, expense_category_id)"
-      : "expense_details(total_amount, purpose, receipt_file_path, bank_statement_file_path, master_expense_categories(name))";
-
     let query = client
-      .from("claims")
+      .from("vw_enterprise_claims_dashboard")
       .select(
-        `id, employee_id, detail_type, submission_type, on_behalf_email, on_behalf_employee_code, status, submitted_at, created_at, hod_action_at, finance_action_at, submitter_user:users!claims_submitted_by_fkey!inner(full_name, email), master_departments(name), master_payment_modes(name), ${expenseDetailsJoin}, advance_details(requested_amount, purpose, supporting_document_path)`,
+        "claim_id, employee_name, employee_id, detail_type, submission_type, on_behalf_email, on_behalf_employee_code_raw, status, submitted_on, created_at, hod_action_date, finance_action_date, submitter_email, submitter_label, department_name, type_of_claim, amount, category_name, purpose, receipt_file_path, bank_statement_file_path, supporting_document_path, payment_mode_id, department_id, location_id, product_id, expense_category_id",
         { count: "exact" },
       )
       .eq("assigned_l1_approver_id", userId)
-      .eq("is_active", true)
       .order("created_at", { ascending: false })
-      .order("id", { ascending: false });
+      .order("claim_id", { ascending: false });
 
     query = applyPendingApprovalsFilters({
       query,
@@ -3123,12 +2892,11 @@ export class SupabaseClaimRepository implements ClaimRepository {
       toDate,
       dateColumn,
       normalizedSearch,
-      submitterUserIdsFilter,
     });
 
     if (decodedCursor) {
       query = query.or(
-        `created_at.lt.${decodedCursor.createdAt},and(created_at.eq.${decodedCursor.createdAt},id.lt.${decodedCursor.id})`,
+        `created_at.lt.${decodedCursor.createdAt},and(created_at.eq.${decodedCursor.createdAt},claim_id.lt.${decodedCursor.id})`,
       );
     }
 
@@ -3144,13 +2912,13 @@ export class SupabaseClaimRepository implements ClaimRepository {
       };
     }
 
-    const rows = (data ?? []) as GetPendingApprovalsRow[];
+    const rows = (data ?? []) as EnterpriseClaimsDashboardRow[];
     const hasExtraRecord = rows.length > safeLimit;
     const pageRows = hasExtraRecord ? rows.slice(0, safeLimit) : rows;
     const lastRow = pageRows[pageRows.length - 1] ?? null;
     const nextCursor =
       hasExtraRecord && lastRow
-        ? encodeClaimsCursor({ createdAt: lastRow.created_at, id: lastRow.id })
+        ? encodeClaimsCursor({ createdAt: lastRow.created_at, id: lastRow.claim_id })
         : null;
 
     return {
@@ -3200,9 +2968,12 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const decodedCursor = decodeClaimsCursor(cursor);
     const normalizedStatuses = normalizeFinanceVisibleStatusFilter(filters?.status);
     const { fromDate, toDate } = normalizeDateRange(filters);
-    // Default to finance_action_at so date-range filters reflect when the Finance approver acted,
+    // Default to finance_action_date so date-range filters reflect when the Finance approver acted,
     // not when the submitter originally submitted the claim.
-    const dateColumn = resolvePendingApprovalsDateColumn(filters?.dateTarget, "finance_action_at");
+    const dateColumn = resolvePendingApprovalsDateColumn(
+      filters?.dateTarget,
+      "finance_action_date",
+    );
     const normalizedSearch = normalizeSearchInput(filters);
     const safeLimit = clampListPageSize(limit);
 
@@ -3226,52 +2997,23 @@ export class SupabaseClaimRepository implements ClaimRepository {
       };
     }
 
-    let submitterUserIdsFilter = getNeverMatchUserIdFilter();
-
-    if (normalizedSearch.query && normalizedSearch.field === "employee_email") {
-      const submitterUserIdsFilterResult = await resolveSubmitterUserIdsFilter({
-        client,
-        searchQuery: normalizedSearch.query,
-      });
-
-      if (submitterUserIdsFilterResult.errorMessage) {
-        return {
-          data: [],
-          nextCursor: null,
-          hasNextPage: false,
-          totalCount: 0,
-          errorMessage: submitterUserIdsFilterResult.errorMessage,
-        };
-      }
-
-      submitterUserIdsFilter = submitterUserIdsFilterResult.data;
-    }
-
     const financeNonRejectedStatusesFilter = toPostgrestInList(
       FINANCE_NON_REJECTED_VISIBLE_STATUSES,
     );
     const financeRejectedStatusesFilter = toPostgrestInList(FINANCE_REJECTED_VISIBLE_STATUSES);
 
-    const needsExpenseInnerJoin =
-      filters?.locationId || filters?.productId || filters?.expenseCategoryId;
-
-    const expenseDetailsJoin = needsExpenseInnerJoin
-      ? "expense_details!inner(total_amount, purpose, receipt_file_path, bank_statement_file_path, master_expense_categories(name), location_id, product_id, expense_category_id)"
-      : "expense_details(total_amount, purpose, receipt_file_path, bank_statement_file_path, master_expense_categories(name))";
-
     let query = client
-      .from("claims")
+      .from("vw_enterprise_claims_dashboard")
       .select(
-        `id, employee_id, detail_type, submission_type, on_behalf_email, on_behalf_employee_code, status, submitted_at, created_at, hod_action_at, finance_action_at, submitter_user:users!claims_submitted_by_fkey!inner(full_name, email), master_departments(name), master_payment_modes(name), ${expenseDetailsJoin}, advance_details(requested_amount, purpose, supporting_document_path)`,
+        "claim_id, employee_name, employee_id, detail_type, submission_type, on_behalf_email, on_behalf_employee_code_raw, status, submitted_on, created_at, hod_action_date, finance_action_date, submitter_email, submitter_label, department_name, type_of_claim, amount, category_name, purpose, receipt_file_path, bank_statement_file_path, supporting_document_path, assigned_l2_approver_id, payment_mode_id, department_id, location_id, product_id, expense_category_id",
         { count: "exact" },
       )
       .or(
         `status.in.${financeNonRejectedStatusesFilter},and(status.in.${financeRejectedStatusesFilter},assigned_l2_approver_id.not.is.null)`,
       )
       .not("status", "in", FINANCE_EXCLUDED_QUEUE_AND_HISTORY_STATUSES_FILTER)
-      .eq("is_active", true)
       .order("created_at", { ascending: false })
-      .order("id", { ascending: false });
+      .order("claim_id", { ascending: false });
 
     query = applyPendingApprovalsFilters({
       query,
@@ -3281,12 +3023,11 @@ export class SupabaseClaimRepository implements ClaimRepository {
       toDate,
       dateColumn,
       normalizedSearch,
-      submitterUserIdsFilter,
     });
 
     if (decodedCursor) {
       query = query.or(
-        `created_at.lt.${decodedCursor.createdAt},and(created_at.eq.${decodedCursor.createdAt},id.lt.${decodedCursor.id})`,
+        `created_at.lt.${decodedCursor.createdAt},and(created_at.eq.${decodedCursor.createdAt},claim_id.lt.${decodedCursor.id})`,
       );
     }
 
@@ -3302,13 +3043,13 @@ export class SupabaseClaimRepository implements ClaimRepository {
       };
     }
 
-    const rows = (data ?? []) as GetPendingApprovalsRow[];
+    const rows = (data ?? []) as EnterpriseClaimsDashboardRow[];
     const hasExtraRecord = rows.length > safeLimit;
     const pageRows = hasExtraRecord ? rows.slice(0, safeLimit) : rows;
     const lastRow = pageRows[pageRows.length - 1] ?? null;
     const nextCursor =
       hasExtraRecord && lastRow
-        ? encodeClaimsCursor({ createdAt: lastRow.created_at, id: lastRow.id })
+        ? encodeClaimsCursor({ createdAt: lastRow.created_at, id: lastRow.claim_id })
         : null;
 
     return {

--- a/src/modules/claims/repositories/SupabaseClaimRepository.ts
+++ b/src/modules/claims/repositories/SupabaseClaimRepository.ts
@@ -15,6 +15,7 @@ import {
 } from "@/core/constants/statuses";
 import type {
   ClaimAuditActionType,
+  ClaimExpenseAiMetadata,
   ClaimAuditLogRecord,
   ClaimDateTarget,
   ClaimDepartmentApprovers,
@@ -221,6 +222,7 @@ type ClaimDetailExpenseRow = {
   product_id: string | null;
   people_involved: string | null;
   remarks: string | null;
+  ai_metadata: Record<string, unknown> | null;
   receipt_file_path: string | null;
   bank_statement_file_path: string | null;
   master_expense_categories: ClaimRelationNameRow | ClaimRelationNameRow[] | null;
@@ -424,6 +426,50 @@ function toNumber(value: number | string | null | undefined): number | null {
   }
 
   return null;
+}
+
+function parseClaimExpenseAiMetadata(
+  value: Record<string, unknown> | null,
+): ClaimExpenseAiMetadata | null {
+  if (!value) {
+    return null;
+  }
+
+  const editedFieldsCandidate = value.edited_fields;
+  if (
+    !editedFieldsCandidate ||
+    typeof editedFieldsCandidate !== "object" ||
+    Array.isArray(editedFieldsCandidate)
+  ) {
+    return null;
+  }
+
+  const editedFields = editedFieldsCandidate as Record<string, unknown>;
+  const normalized: Record<string, { original: string | number | boolean | null }> = {};
+
+  for (const [field, entry] of Object.entries(editedFields)) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+
+    const original = (entry as { original?: unknown }).original;
+    if (
+      typeof original === "string" ||
+      typeof original === "number" ||
+      typeof original === "boolean" ||
+      original === null
+    ) {
+      normalized[field] = { original };
+    }
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    return null;
+  }
+
+  return {
+    edited_fields: normalized,
+  };
 }
 
 const FINANCE_NON_REJECTED_VISIBLE_STATUSES: DbClaimStatus[] = [
@@ -1816,6 +1862,7 @@ export class SupabaseClaimRepository implements ClaimRepository {
         productId: string | null;
         peopleInvolved: string | null;
         remarks: string | null;
+        aiMetadata: ClaimExpenseAiMetadata | null;
         receiptFilePath: string | null;
         bankStatementFilePath: string | null;
       } | null;
@@ -1836,7 +1883,7 @@ export class SupabaseClaimRepository implements ClaimRepository {
     const { data, error } = await client
       .from("claims")
       .select(
-        "id, employee_id, submission_type, detail_type, on_behalf_of_id, on_behalf_email, on_behalf_employee_code, status, rejection_reason, is_resubmission_allowed, submitted_at, department_id, payment_mode_id, assigned_l1_approver_id, assigned_l2_approver_id, submitted_by, submitter_user:users!claims_submitted_by_fkey(full_name, email), beneficiary_user:users!claims_on_behalf_of_id_fkey(full_name, email), master_departments(name), master_payment_modes(name), expense_details(id, bill_no, purpose, expense_category_id, product_id, location_id, location_type, location_details, is_gst_applicable, gst_number, transaction_date, basic_amount, cgst_amount, sgst_amount, igst_amount, total_amount, vendor_name, people_involved, remarks, receipt_file_path, bank_statement_file_path, master_expense_categories(name), master_products(name), master_locations(name)), advance_details(id, purpose, requested_amount, expected_usage_date, product_id, location_id, remarks, supporting_document_path)",
+        "id, employee_id, submission_type, detail_type, on_behalf_of_id, on_behalf_email, on_behalf_employee_code, status, rejection_reason, is_resubmission_allowed, submitted_at, department_id, payment_mode_id, assigned_l1_approver_id, assigned_l2_approver_id, submitted_by, submitter_user:users!claims_submitted_by_fkey(full_name, email), beneficiary_user:users!claims_on_behalf_of_id_fkey(full_name, email), master_departments(name), master_payment_modes(name), expense_details(id, bill_no, purpose, expense_category_id, product_id, location_id, location_type, location_details, is_gst_applicable, gst_number, transaction_date, basic_amount, cgst_amount, sgst_amount, igst_amount, total_amount, vendor_name, people_involved, remarks, ai_metadata, receipt_file_path, bank_statement_file_path, master_expense_categories(name), master_products(name), master_locations(name)), advance_details(id, purpose, requested_amount, expected_usage_date, product_id, location_id, remarks, supporting_document_path)",
       )
       .eq("id", claimId)
       .eq("is_active", true)
@@ -1917,6 +1964,7 @@ export class SupabaseClaimRepository implements ClaimRepository {
               productId: expense.product_id,
               peopleInvolved: expense.people_involved,
               remarks: expense.remarks,
+              aiMetadata: parseClaimExpenseAiMetadata(expense.ai_metadata),
               receiptFilePath: expense.receipt_file_path,
               bankStatementFilePath: expense.bank_statement_file_path,
             }

--- a/src/modules/claims/repositories/SupabaseDepartmentViewerRepository.ts
+++ b/src/modules/claims/repositories/SupabaseDepartmentViewerRepository.ts
@@ -52,8 +52,39 @@ function normalizeRelation<T>(value: T | T[] | null | undefined): T | null {
   return value;
 }
 
+const POSTGREST_SUBMISSION_TYPE_SELF = '"Self"';
+const POSTGREST_SUBMISSION_TYPE_ON_BEHALF = '"On Behalf"';
+
+function buildBeneficiaryScopedSearchOrFilter(input: {
+  searchQuery: string;
+  selfField: string;
+  onBehalfField: string;
+}): string {
+  return `and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_SELF},${input.selfField}.ilike.%${input.searchQuery}%),and(submission_type.eq.${POSTGREST_SUBMISSION_TYPE_ON_BEHALF},${input.onBehalfField}.ilike.%${input.searchQuery}%)`;
+}
+
+function buildEmployeeNameSearchOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "submitter_name_raw",
+    onBehalfField: "beneficiary_name_raw",
+  });
+}
+
+function buildEmployeeEmailSearchOrFilter(searchQuery: string): string {
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "submitter_email",
+    onBehalfField: "on_behalf_email",
+  });
+}
+
 function buildEmployeeIdSearchOrFilter(searchQuery: string): string {
-  return `claim_employee_id_raw.ilike.%${searchQuery}%,on_behalf_employee_code_raw.ilike.%${searchQuery}%,submitter_email.ilike.%${searchQuery}%,on_behalf_email.ilike.%${searchQuery}%`;
+  return buildBeneficiaryScopedSearchOrFilter({
+    searchQuery,
+    selfField: "claim_employee_id_raw",
+    onBehalfField: "on_behalf_employee_code_raw",
+  });
 }
 
 // ----------------------------------------------------------------
@@ -133,16 +164,16 @@ export class SupabaseDepartmentViewerRepository implements DepartmentViewerRepos
     if (filters.searchQuery) {
       const sq = filters.searchQuery;
       if (filters.searchField === "claim_id") {
-        query = query.eq("claim_id", sq);
+        query = query.ilike("claim_id", `%${sq}%`);
       } else if (filters.searchField === "employee_name") {
-        query = query.ilike("employee_name", `%${sq}%`);
+        query = query.or(buildEmployeeNameSearchOrFilter(sq));
       } else if (filters.searchField === "employee_id") {
         query = query.or(buildEmployeeIdSearchOrFilter(sq));
       } else if (filters.searchField === "employee_email") {
-        query = query.or(`submitter_email.ilike.%${sq}%,on_behalf_email.ilike.%${sq}%`);
+        query = query.or(buildEmployeeEmailSearchOrFilter(sq));
       } else {
         query = query.or(
-          `claim_id.ilike.%${sq}%,employee_name.ilike.%${sq}%,${buildEmployeeIdSearchOrFilter(sq)}`,
+          `claim_id.ilike.%${sq}%,${buildEmployeeNameSearchOrFilter(sq)},${buildEmployeeIdSearchOrFilter(sq)},${buildEmployeeEmailSearchOrFilter(sq)}`,
         );
       }
     }

--- a/src/modules/claims/ui/approvals-quick-view-sheet.tsx
+++ b/src/modules/claims/ui/approvals-quick-view-sheet.tsx
@@ -495,6 +495,7 @@ export function ApprovalsAuditModeDialog({
 
   const resolvedClaim: QuickViewClaimRecord | null = hydratedData?.claim ?? null;
   const resolvedAuditLogs = hydratedData?.auditLogs ?? auditLogs;
+  const canViewAiMetadata = hydratedData?.canViewAiMetadata ?? false;
   const hasActions = Boolean(children);
   const canRenderInlineEdit = canInlineEdit && hasActions;
   const claimTypeLabel = detailType === "expense" ? "Expense Claim" : "Advance Claim";
@@ -856,7 +857,11 @@ export function ApprovalsAuditModeDialog({
                         {isHydrating && !resolvedClaim ? (
                           <ClaimFullDetailsGridSkeleton />
                         ) : resolvedClaim ? (
-                          <ClaimFullDetailsGrid claim={resolvedClaim} viewMode="quick-view" />
+                          <ClaimFullDetailsGrid
+                            claim={resolvedClaim}
+                            viewMode="quick-view"
+                            showAiWarnings={canViewAiMetadata}
+                          />
                         ) : (
                           <div className="rounded-[20px] border border-rose-200/80 bg-rose-50/80 p-4 text-sm text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/30 dark:text-rose-200">
                             Unable to load full claim details right now.

--- a/src/modules/claims/ui/claim-full-details-grid.tsx
+++ b/src/modules/claims/ui/claim-full-details-grid.tsx
@@ -1,4 +1,9 @@
 import { formatDate } from "@/lib/format";
+import type { ReactNode } from "react";
+
+type ClaimExpenseAiMetadata = {
+  edited_fields: Record<string, { original: string | number | boolean | null }>;
+};
 
 type ClaimExpenseDetail = {
   id: string;
@@ -20,6 +25,7 @@ type ClaimExpenseDetail = {
   vendorName: string | null;
   peopleInvolved: string | null;
   remarks: string | null;
+  aiMetadata?: ClaimExpenseAiMetadata | null;
 };
 
 type ClaimAdvanceDetail = {
@@ -43,7 +49,16 @@ type ClaimFullDetailsGridProps = {
   includeExpenseDetail?: boolean;
   includeAdvanceDetail?: boolean;
   viewMode?: "full" | "quick-view";
+  showAiWarnings?: boolean;
 };
+
+const AI_AMOUNT_FIELDS = new Set([
+  "basic_amount",
+  "cgst_amount",
+  "sgst_amount",
+  "igst_amount",
+  "total_amount",
+]);
 
 const indiaAmountFormatter = new Intl.NumberFormat("en-IN", {
   style: "currency",
@@ -75,6 +90,7 @@ export function ClaimFullDetailsGrid({
   includeExpenseDetail = true,
   includeAdvanceDetail = true,
   viewMode = "full",
+  showAiWarnings = false,
 }: ClaimFullDetailsGridProps) {
   const isQuickViewMode = viewMode === "quick-view";
   const summaryGridClasses = isQuickViewMode
@@ -91,6 +107,47 @@ export function ClaimFullDetailsGrid({
   const transactionDate =
     claim.expense?.transactionDate ?? claim.advance?.expectedUsageDate ?? null;
   const categoryLabel = claim.expense?.expenseCategoryName ?? (claim.advance ? "Advance" : null);
+  const editedFields = showAiWarnings ? claim.expense?.aiMetadata?.edited_fields : undefined;
+
+  const getAiOriginalValue = (field: string): string | number | boolean | null | undefined => {
+    return editedFields?.[field]?.original;
+  };
+
+  const formatAiOriginalValue = (
+    field: string,
+    value: string | number | boolean | null,
+  ): string => {
+    if (value === null) {
+      return "N/A";
+    }
+
+    if (AI_AMOUNT_FIELDS.has(field) && typeof value === "number") {
+      return formatAmount(value);
+    }
+
+    if (field === "transaction_date" && typeof value === "string") {
+      return formatDate(value);
+    }
+
+    if (typeof value === "boolean") {
+      return value ? "Yes" : "No";
+    }
+
+    return String(value);
+  };
+
+  const renderAiWarning = (field: string): ReactNode => {
+    const originalValue = getAiOriginalValue(field);
+    if (originalValue === undefined) {
+      return null;
+    }
+
+    return (
+      <p className="mt-1 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+        AI originally read: {formatAiOriginalValue(field, originalValue)}
+      </p>
+    );
+  };
 
   return (
     <>
@@ -180,6 +237,7 @@ export function ClaimFullDetailsGrid({
               <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                 {formatOptionalText(claim.expense.billNo, "-")}
               </p>
+              {renderAiWarning("bill_no")}
             </div>
             {isQuickViewMode ? null : (
               <div>
@@ -189,6 +247,7 @@ export function ClaimFullDetailsGrid({
                 <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                   {formatOptionalText(claim.expense.vendorName)}
                 </p>
+                {renderAiWarning("vendor_name")}
               </div>
             )}
             <div>
@@ -198,6 +257,7 @@ export function ClaimFullDetailsGrid({
               <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                 {formatDate(claim.expense.transactionDate)}
               </p>
+              {renderAiWarning("transaction_date")}
             </div>
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-indigo-500 dark:text-indigo-400">
@@ -206,6 +266,7 @@ export function ClaimFullDetailsGrid({
               <p className="mt-0.5 text-sm font-bold text-slate-900 dark:text-slate-100">
                 {formatAmount(claim.expense.totalAmount)}
               </p>
+              {renderAiWarning("total_amount")}
             </div>
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -224,6 +285,7 @@ export function ClaimFullDetailsGrid({
                   <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                     {formatOptionalText(claim.expense.expenseCategoryName)}
                   </p>
+                  {renderAiWarning("expense_category_id")}
                 </div>
                 <div>
                   <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -280,6 +342,7 @@ export function ClaimFullDetailsGrid({
                   <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                     {formatOptionalText(claim.expense.gstNumber)}
                   </p>
+                  {renderAiWarning("gst_number")}
                 </div>
                 <div>
                   <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -288,6 +351,7 @@ export function ClaimFullDetailsGrid({
                   <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                     {formatAmount(claim.expense.basicAmount)}
                   </p>
+                  {renderAiWarning("basic_amount")}
                 </div>
                 {shouldShowExpenseTaxBreakdown ? (
                   <>
@@ -298,6 +362,7 @@ export function ClaimFullDetailsGrid({
                       <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                         {formatAmount(claim.expense.cgstAmount)}
                       </p>
+                      {renderAiWarning("cgst_amount")}
                     </div>
                     <div>
                       <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -306,6 +371,7 @@ export function ClaimFullDetailsGrid({
                       <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                         {formatAmount(claim.expense.sgstAmount)}
                       </p>
+                      {renderAiWarning("sgst_amount")}
                     </div>
                     <div>
                       <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
@@ -314,6 +380,7 @@ export function ClaimFullDetailsGrid({
                       <p className="mt-0.5 text-sm font-medium text-slate-900 dark:text-slate-100">
                         {formatAmount(claim.expense.igstAmount)}
                       </p>
+                      {renderAiWarning("igst_amount")}
                     </div>
                   </>
                 ) : null}

--- a/src/modules/claims/ui/new-claim-form-client.tsx
+++ b/src/modules/claims/ui/new-claim-form-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useWatch, type FieldErrors } from "react-hook-form";
 import { useRouter } from "next/navigation";
@@ -244,6 +244,107 @@ function appendFormDataValue(
   formData.append(key, String(value));
 }
 
+type AiEditedFieldEntry = {
+  original: string | number | boolean | null;
+};
+
+type ClaimExpenseAiMetadataPayload = {
+  edited_fields: Record<string, AiEditedFieldEntry>;
+};
+
+type AiExpenseSnapshot = {
+  bill_no: string | null;
+  transaction_date: string | null;
+  vendor_name: string | null;
+  gst_number: string | null;
+  expense_category_id: string | null;
+  basic_amount: number;
+  cgst_amount: number;
+  sgst_amount: number;
+  igst_amount: number;
+  total_amount: number;
+};
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function equalsRoundedAmount(left: number, right: number, tolerance = 0.01): boolean {
+  return Math.abs(left - right) <= tolerance;
+}
+
+function buildExpenseAiMetadata(
+  snapshot: AiExpenseSnapshot | null,
+  expense: ClaimFormDraftValues["expense"],
+): ClaimExpenseAiMetadataPayload | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  const editedFields: Record<string, AiEditedFieldEntry> = {};
+
+  const currentTotalAmount = calculateExpenseTotal(
+    expense.basicAmount,
+    expense.cgstAmount,
+    expense.sgstAmount,
+    expense.igstAmount,
+  );
+
+  const comparisons: Array<{
+    key: keyof AiExpenseSnapshot;
+    currentValue: string | number | null;
+  }> = [
+    { key: "bill_no", currentValue: normalizeOptionalText(expense.billNo) },
+    { key: "transaction_date", currentValue: normalizeOptionalText(expense.transactionDate) },
+    { key: "vendor_name", currentValue: normalizeOptionalText(expense.vendorName) },
+    { key: "gst_number", currentValue: normalizeOptionalText(expense.gstNumber) },
+    {
+      key: "expense_category_id",
+      currentValue: normalizeOptionalText(expense.expenseCategoryId),
+    },
+    { key: "basic_amount", currentValue: expense.basicAmount },
+    { key: "cgst_amount", currentValue: expense.cgstAmount },
+    { key: "sgst_amount", currentValue: expense.sgstAmount },
+    { key: "igst_amount", currentValue: expense.igstAmount },
+    { key: "total_amount", currentValue: currentTotalAmount },
+  ];
+
+  for (const comparison of comparisons) {
+    const originalValue = snapshot[comparison.key];
+    const currentValue = comparison.currentValue;
+
+    if (typeof originalValue === "number" && typeof currentValue === "number") {
+      if (!equalsRoundedAmount(originalValue, currentValue)) {
+        editedFields[comparison.key] = { original: originalValue };
+      }
+      continue;
+    }
+
+    if (originalValue === null) {
+      continue;
+    }
+
+    if (originalValue !== currentValue) {
+      editedFields[comparison.key] = {
+        original: typeof originalValue === "string" ? normalizeOptionalText(originalValue) : null,
+      };
+    }
+  }
+
+  if (Object.keys(editedFields).length === 0) {
+    return null;
+  }
+
+  return {
+    edited_fields: editedFields,
+  };
+}
+
 export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientProps) {
   const router = useRouter();
   const [, startNavTransition] = useTransition();
@@ -253,6 +354,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
   const [advanceSupportingFile, setAdvanceSupportingFile] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isAiParsing, setIsAiParsing] = useState(false);
+  const originalAiExpenseSnapshotRef = useRef<AiExpenseSnapshot | null>(null);
 
   const defaultPaymentMode = options.paymentModes[0];
 
@@ -538,6 +640,11 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
     appendFormDataValue(formData, "detailType", values.detailType);
 
     if (values.detailType === "expense") {
+      const aiMetadata = buildExpenseAiMetadata(
+        originalAiExpenseSnapshotRef.current,
+        values.expense,
+      );
+
       appendFormDataValue(formData, "expense.billNo", values.expense.billNo);
       appendFormDataValue(formData, "expense.purpose", values.expense.purpose);
       appendFormDataValue(formData, "expense.expenseCategoryId", values.expense.expenseCategoryId);
@@ -571,6 +678,10 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
       appendFormDataValue(formData, "expense.bankStatementFileName", "");
       appendFormDataValue(formData, "expense.bankStatementFileType", "");
       appendFormDataValue(formData, "expense.bankStatementFileBase64", "");
+
+      if (aiMetadata) {
+        appendFormDataValue(formData, "expense.aiMetadata", JSON.stringify(aiMetadata));
+      }
 
       if (invoiceFile) {
         formData.append("receiptFile", invoiceFile);
@@ -677,6 +788,19 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
       parsedCategoryName,
       options.expenseCategories,
     );
+
+    originalAiExpenseSnapshotRef.current = {
+      bill_no: normalizeOptionalText(billNo),
+      transaction_date: normalizeOptionalText(transactionDate),
+      vendor_name: normalizeOptionalText(vendorName),
+      gst_number: normalizeOptionalText(gstNumber),
+      expense_category_id: normalizeOptionalText(matchedExpenseCategoryId),
+      basic_amount: basicAmount,
+      cgst_amount: cgstAmount,
+      sgst_amount: sgstAmount,
+      igst_amount: igstAmount,
+      total_amount: normalizedTotalAmount,
+    };
 
     setValue("expense.billNo", billNo, {
       shouldDirty: true,
@@ -788,6 +912,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
     });
 
     if (!selectedFile) {
+      originalAiExpenseSnapshotRef.current = null;
       setFileError(null);
       return;
     }
@@ -803,6 +928,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
       return;
     }
 
+    originalAiExpenseSnapshotRef.current = null;
     setFileError(null);
     const toastId = toast.loading("Fetching AI details...");
     await runReceiptExtraction(selectedFile, toastId);
@@ -825,6 +951,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
       return;
     }
 
+    originalAiExpenseSnapshotRef.current = null;
     setFileError(null);
 
     const toastId = toast.loading("Fetching AI details...");

--- a/src/modules/claims/validators/new-claim-schema.ts
+++ b/src/modules/claims/validators/new-claim-schema.ts
@@ -37,6 +37,12 @@ const optionalTaxAmountSchema = z.preprocess(
   z.number().min(0, "Tax amount cannot be negative"),
 );
 
+const aiOriginalValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+const aiMetadataSchema = z.object({
+  edited_fields: z.record(z.string(), z.object({ original: aiOriginalValueSchema })),
+});
+
 const baseSubmissionSchema = z.object({
   employeeName: z.string().trim().min(1, "Employee Name is required"),
   employeeId: z.string().trim().min(1, "Employee ID is required"),
@@ -90,6 +96,7 @@ const expenseDetailSchema = z.object({
     bankStatementFileBase64: optionalTextToNA,
     peopleInvolved: optionalTextToNA,
     remarks: optionalTextToNA,
+    aiMetadata: aiMetadataSchema.optional().nullable(),
   }),
   advance: z.object({}).passthrough().optional(),
 });

--- a/supabase/migrations/20260415044442_add_ai_metadata_tracking.sql
+++ b/supabase/migrations/20260415044442_add_ai_metadata_tracking.sql
@@ -1,0 +1,207 @@
+-- Shadow tracking: store AI-parsed originals for fields edited before claim submission.
+
+ALTER TABLE public.expense_details
+  ADD COLUMN ai_metadata JSONB DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.expense_details.ai_metadata IS 'AI extraction audit metadata, including edited_fields originals for finance/admin review.';
+
+CREATE OR REPLACE FUNCTION public.create_claim_with_detail(p_payload jsonb)
+ RETURNS text
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_claim_id text;
+  v_initial_status public.claim_status;
+  v_payment_mode_name text;
+  v_expected_detail_type text;
+  v_detail_type text;
+  v_basic_amount numeric;
+  v_cgst_amount numeric;
+  v_sgst_amount numeric;
+  v_igst_amount numeric;
+  v_is_gst_applicable boolean;
+  v_advance_requested_amount numeric;
+  v_advance_budget_month integer;
+  v_advance_budget_year integer;
+begin
+  v_claim_id := nullif(trim(p_payload->>'claim_id'), '');
+
+  if v_claim_id is null then
+    raise exception 'claim_id is required';
+  end if;
+
+  if v_claim_id !~ '^(CLAIM|EA)-[A-Za-z0-9]+-[0-9]{8}-[A-Za-z0-9]+$' then
+    raise exception 'claim_id % does not match required format', v_claim_id;
+  end if;
+
+  v_initial_status := coalesce(
+    nullif(trim(p_payload->>'initial_status'), '')::public.claim_status,
+    'Submitted - Awaiting HOD approval'::public.claim_status
+  );
+
+  select name into v_payment_mode_name
+  from public.master_payment_modes
+  where id = (p_payload->>'payment_mode_id')::uuid
+    and is_active = true;
+
+  if v_payment_mode_name is null then
+    raise exception 'Invalid or inactive payment_mode_id';
+  end if;
+
+  if lower(v_payment_mode_name) in ('reimbursement', 'corporate card', 'happay', 'forex', 'petty cash') then
+    v_expected_detail_type := 'expense';
+  elsif lower(v_payment_mode_name) in ('petty cash request', 'bulk petty cash request') then
+    v_expected_detail_type := 'advance';
+  else
+    raise exception 'Payment mode % is not mapped to a claim detail type', v_payment_mode_name;
+  end if;
+
+  v_detail_type := p_payload->>'detail_type';
+  if v_detail_type is distinct from v_expected_detail_type then
+    raise exception 'detail_type % does not match payment mode %', v_detail_type, v_payment_mode_name;
+  end if;
+
+  insert into public.claims (
+    id,
+    status,
+    submission_type,
+    detail_type,
+    submitted_by,
+    on_behalf_of_id,
+    on_behalf_email,
+    on_behalf_employee_code,
+    department_id,
+    payment_mode_id,
+    assigned_l1_approver_id,
+    assigned_l2_approver_id,
+    submitted_at,
+    is_active
+  )
+  values (
+    v_claim_id,
+    v_initial_status,
+    p_payload->>'submission_type',
+    v_detail_type,
+    (p_payload->>'submitted_by')::uuid,
+    (p_payload->>'on_behalf_of_id')::uuid,
+    coalesce(nullif(trim(p_payload->>'on_behalf_email'), ''), 'N/A'),
+    coalesce(nullif(trim(p_payload->>'on_behalf_employee_code'), ''), 'N/A'),
+    (p_payload->>'department_id')::uuid,
+    (p_payload->>'payment_mode_id')::uuid,
+    (p_payload->>'assigned_l1_approver_id')::uuid,
+    nullif(p_payload->>'assigned_l2_approver_id', '')::uuid,
+    now(),
+    true
+  )
+  returning id into v_claim_id;
+
+  if v_detail_type = 'expense' then
+    v_is_gst_applicable := coalesce((p_payload->'expense'->>'is_gst_applicable')::boolean, false);
+    v_basic_amount := (p_payload->'expense'->>'basic_amount')::numeric;
+    v_cgst_amount := case when v_is_gst_applicable then coalesce((p_payload->'expense'->>'cgst_amount')::numeric, 0) else 0 end;
+    v_sgst_amount := case when v_is_gst_applicable then coalesce((p_payload->'expense'->>'sgst_amount')::numeric, 0) else 0 end;
+    v_igst_amount := case when v_is_gst_applicable then coalesce((p_payload->'expense'->>'igst_amount')::numeric, 0) else 0 end;
+
+    insert into public.expense_details (
+      claim_id,
+      bill_no,
+      transaction_id,
+      expense_category_id,
+      product_id,
+      location_id,
+      location_type,
+      location_details,
+      purpose,
+      is_gst_applicable,
+      gst_number,
+      cgst_amount,
+      sgst_amount,
+      igst_amount,
+      transaction_date,
+      basic_amount,
+      currency_code,
+      vendor_name,
+      receipt_file_path,
+      bank_statement_file_path,
+      people_involved,
+      remarks,
+      ai_metadata
+    )
+    values (
+      v_claim_id,
+      p_payload->'expense'->>'bill_no',
+      coalesce(nullif(trim(p_payload->'expense'->>'transaction_id'), ''), 'N/A'),
+      (p_payload->'expense'->>'expense_category_id')::uuid,
+      nullif(p_payload->'expense'->>'product_id', '')::uuid,
+      (p_payload->'expense'->>'location_id')::uuid,
+      nullif(trim(p_payload->'expense'->>'location_type'), ''),
+      nullif(trim(p_payload->'expense'->>'location_details'), ''),
+      coalesce(nullif(trim(p_payload->'expense'->>'purpose'), ''), 'N/A'),
+      v_is_gst_applicable,
+      coalesce(nullif(trim(p_payload->'expense'->>'gst_number'), ''), 'N/A'),
+      v_cgst_amount,
+      v_sgst_amount,
+      v_igst_amount,
+      (p_payload->'expense'->>'transaction_date')::date,
+      v_basic_amount,
+      coalesce(nullif(trim(p_payload->'expense'->>'currency_code'), ''), 'INR'),
+      coalesce(nullif(trim(p_payload->'expense'->>'vendor_name'), ''), 'N/A'),
+      coalesce(nullif(trim(p_payload->'expense'->>'receipt_file_path'), ''), 'N/A'),
+      coalesce(nullif(trim(p_payload->'expense'->>'bank_statement_file_path'), ''), 'N/A'),
+      coalesce(nullif(trim(p_payload->'expense'->>'people_involved'), ''), 'N/A'),
+      coalesce(nullif(trim(p_payload->'expense'->>'remarks'), ''), 'N/A'),
+      coalesce(p_payload->'expense'->'ai_metadata', '{}'::jsonb)
+    );
+  end if;
+
+  if v_detail_type = 'advance' then
+    v_advance_requested_amount := (p_payload->'advance'->>'requested_amount')::numeric;
+    v_advance_budget_month := (p_payload->'advance'->>'budget_month')::integer;
+    v_advance_budget_year := (p_payload->'advance'->>'budget_year')::integer;
+
+    if v_advance_requested_amount is null then
+      raise exception 'Advance requested_amount is required';
+    end if;
+    if v_advance_requested_amount <= 0 then
+      raise exception 'Advance requested_amount must be greater than zero';
+    end if;
+    if v_advance_budget_month is null then
+      raise exception 'Advance budget_month is required';
+    end if;
+    if v_advance_budget_year is null then
+      raise exception 'Advance budget_year is required';
+    end if;
+
+    insert into public.advance_details (
+      claim_id,
+      requested_amount,
+      budget_month,
+      budget_year,
+      expected_usage_date,
+      purpose,
+      product_id,
+      location_id,
+      supporting_document_path,
+      remarks
+    )
+    values (
+      v_claim_id,
+      v_advance_requested_amount,
+      v_advance_budget_month,
+      v_advance_budget_year,
+      nullif(p_payload->'advance'->>'expected_usage_date', '')::date,
+      coalesce(nullif(trim(p_payload->'advance'->>'purpose'), ''), 'N/A'),
+      nullif(p_payload->'advance'->>'product_id', '')::uuid,
+      nullif(p_payload->'advance'->>'location_id', '')::uuid,
+      coalesce(nullif(trim(p_payload->'advance'->>'supporting_document_path'), ''), 'N/A'),
+      coalesce(nullif(trim(p_payload->'advance'->>'remarks'), ''), 'N/A')
+    );
+  end if;
+
+  return v_claim_id;
+end;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.create_claim_with_detail(jsonb) TO authenticated;

--- a/supabase/migrations/20260415113000_add_beneficiary_name_columns_to_enterprise_dashboard_view.sql
+++ b/supabase/migrations/20260415113000_add_beneficiary_name_columns_to_enterprise_dashboard_view.sql
@@ -1,0 +1,123 @@
+-- Beneficiary-aware search support: expose submitter and beneficiary name columns.
+
+drop view if exists public.vw_enterprise_claims_dashboard;
+
+create view public.vw_enterprise_claims_dashboard as
+select
+  c.id as claim_id,
+  coalesce(
+    nullif(trim(u.full_name), ''),
+    nullif(trim(split_part(u.email, '@', 1)), ''),
+    nullif(trim(c.employee_id), ''),
+    nullif(trim(c.on_behalf_email), ''),
+    'N/A'
+  ) as employee_name,
+  coalesce(
+    nullif(trim(c.employee_id), ''),
+    nullif(trim(c.on_behalf_employee_code), ''),
+    nullif(trim(c.on_behalf_email), ''),
+    nullif(trim(u.email), ''),
+    'N/A'
+  ) as employee_id,
+  c.employee_id as claim_employee_id_raw,
+  c.on_behalf_employee_code as on_behalf_employee_code_raw,
+  nullif(trim(u.full_name), '') as submitter_name_raw,
+  nullif(trim(beneficiary.full_name), '') as beneficiary_name_raw,
+  coalesce(nullif(trim(md.name), ''), 'Unknown Department') as department_name,
+  coalesce(
+    nullif(trim(mpm.name), ''),
+    case
+      when c.detail_type = 'advance' then 'Advance'
+      when c.detail_type = 'expense' then 'Expense'
+      else 'Unknown'
+    end
+  ) as type_of_claim,
+  coalesce(ed.total_amount, ad.requested_amount, 0)::numeric(14,2) as amount,
+  c.status,
+  coalesce(c.submitted_at, c.created_at) as submitted_on,
+  coalesce(
+    c.hod_action_at,
+    case
+      when c.status = 'HOD approved - Awaiting finance approval'::public.claim_status then c.updated_at
+      when c.status in (
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ) and c.assigned_l2_approver_id is null then c.updated_at
+      else null
+    end
+  ) as hod_action_date,
+  coalesce(
+    c.finance_action_at,
+    case
+      when c.status in (
+        'Finance Approved - Payment under process'::public.claim_status,
+        'Payment Done - Closed'::public.claim_status
+      ) then c.updated_at
+      when c.status in (
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ) and c.assigned_l2_approver_id is not null then c.updated_at
+      else null
+    end
+  ) as finance_action_date,
+  coalesce(ed.location_id, ad.location_id) as location_id,
+  coalesce(ed.product_id, ad.product_id) as product_id,
+  ed.expense_category_id as expense_category_id,
+  c.submitted_by,
+  c.on_behalf_of_id,
+  c.on_behalf_email,
+  c.assigned_l1_approver_id,
+  c.assigned_l2_approver_id,
+  c.department_id,
+  c.payment_mode_id,
+  c.detail_type,
+  c.submission_type,
+  c.is_active,
+  c.created_at,
+  c.updated_at,
+  u.email as submitter_email,
+  hod.email as hod_email,
+  finance.email as finance_email,
+  case
+    when nullif(trim(u.full_name), '') is not null and nullif(trim(u.email), '') is not null
+      then trim(u.full_name) || ' (' || trim(u.email) || ')'
+    when nullif(trim(u.full_name), '') is not null
+      then trim(u.full_name)
+    when nullif(trim(u.email), '') is not null
+      then trim(u.email)
+    else c.employee_id
+  end as submitter_label,
+  case
+    when c.detail_type = 'expense'
+      then coalesce(nullif(trim(mec_name.name), ''), 'Uncategorized')
+    else 'Advance'
+  end as category_name,
+  coalesce(ed.purpose, ad.purpose) as purpose,
+  ed.receipt_file_path,
+  ed.bank_statement_file_path,
+  ad.supporting_document_path
+from public.claims c
+left join public.users u
+  on u.id = c.submitted_by
+left join public.users beneficiary
+  on beneficiary.id = c.on_behalf_of_id
+left join public.users hod
+  on hod.id = c.assigned_l1_approver_id
+left join public.users finance
+  on finance.id = c.assigned_l2_approver_id
+left join public.master_departments md
+  on md.id = c.department_id
+left join public.master_payment_modes mpm
+  on mpm.id = c.payment_mode_id
+left join public.expense_details ed
+  on ed.claim_id = c.id
+  and ed.is_active = true
+left join public.master_expense_categories mec_name
+  on mec_name.id = ed.expense_category_id
+left join public.advance_details ad
+  on ad.claim_id = c.id
+  and ad.is_active = true
+where c.is_active = true;
+
+alter view public.vw_enterprise_claims_dashboard
+  set (security_invoker = on);

--- a/tests/unit/admin/supabase-admin-repository.test.ts
+++ b/tests/unit/admin/supabase-admin-repository.test.ts
@@ -121,6 +121,9 @@ describe("SupabaseAdminRepository", () => {
         claimId: "claim-2",
         employeeName: "Bob",
         employeeId: "EMP-2",
+        submitterEmail: null,
+        onBehalfEmail: null,
+        onBehalfEmployeeCode: null,
         departmentName: "Engineering",
         typeOfClaim: "Expense",
         amount: 100.25,
@@ -208,9 +211,35 @@ describe("SupabaseAdminRepository", () => {
     );
 
     expect(claimsChain.or).toHaveBeenCalledWith(
-      "claim_employee_id_raw.ilike.%EMP-001%,on_behalf_employee_code_raw.ilike.%EMP-001%,submitter_email.ilike.%EMP-001%,on_behalf_email.ilike.%EMP-001%",
+      'and(submission_type.eq."Self",claim_employee_id_raw.ilike.%EMP-001%),and(submission_type.eq."On Behalf",on_behalf_employee_code_raw.ilike.%EMP-001%)',
     );
     expect(claimsChain.ilike).not.toHaveBeenCalledWith("employee_id", "%EMP-001%");
+  });
+
+  test("getAllClaims uses partial claim_id search", async () => {
+    const claimsChain = createQueryChain({
+      data: [],
+      error: null,
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "vw_enterprise_claims_dashboard") {
+        return claimsChain;
+      }
+      return createQueryChain({ data: null, error: null });
+    });
+
+    const repository = new SupabaseAdminRepository();
+    await repository.getAllClaims(
+      {
+        searchField: "claim_id",
+        searchQuery: "CLAIM",
+      },
+      { cursor: null, limit: 10 },
+    );
+
+    expect(claimsChain.ilike).toHaveBeenCalledWith("claim_id", "%CLAIM%");
+    expect(claimsChain.eq).not.toHaveBeenCalledWith("claim_id", "CLAIM");
   });
 
   test("getAllClaims applies amount range filters", async () => {

--- a/tests/unit/claims/actions.test.ts
+++ b/tests/unit/claims/actions.test.ts
@@ -21,6 +21,11 @@ const mockDeleteOwnClaimExecute = jest.fn();
 const mockGetApprovalViewerContext = jest.fn();
 const mockGetClaimForFinanceEdit = jest.fn();
 const mockGetPendingApprovalsForL1 = jest.fn();
+const mockGetClaimDetailById = jest.fn();
+const mockGetClaimAuditLogs = jest.fn();
+const mockGetFinanceApproverIdsForUser = jest.fn();
+const mockGetViewerDepartmentIds = jest.fn();
+const mockIsAdmin = jest.fn();
 const mockRevalidatePath = jest.fn();
 const mockRedirect = jest.fn();
 const mockStorageUpload = jest.fn();
@@ -64,7 +69,18 @@ jest.mock("@/modules/claims/repositories/SupabaseClaimRepository", () => ({
     getApprovalViewerContext: mockGetApprovalViewerContext,
     getClaimForFinanceEdit: mockGetClaimForFinanceEdit,
     getPendingApprovalsForL1: mockGetPendingApprovalsForL1,
+    getClaimDetailById: mockGetClaimDetailById,
+    getClaimAuditLogs: mockGetClaimAuditLogs,
+    getFinanceApproverIdsForUser: mockGetFinanceApproverIdsForUser,
   })),
+}));
+
+jest.mock("@/modules/claims/server/is-department-viewer", () => ({
+  getViewerDepartmentIds: (...args: unknown[]) => mockGetViewerDepartmentIds(...args),
+}));
+
+jest.mock("@/modules/admin/server/is-admin", () => ({
+  isAdmin: (...args: unknown[]) => mockIsAdmin(...args),
 }));
 
 jest.mock("@/core/infra/supabase/server-client", () => ({
@@ -171,6 +187,65 @@ const validExpensePayload = {
     locationId: null,
     remarks: null,
   },
+};
+
+const quickViewClaim = {
+  id: "claim-1",
+  employeeId: "EMP-100",
+  departmentId,
+  paymentModeId,
+  submissionType: "Self" as const,
+  detailType: "expense" as const,
+  onBehalfOfId: null,
+  onBehalfEmail: null,
+  onBehalfEmployeeCode: null,
+  status: "Submitted - Awaiting HOD approval" as const,
+  rejectionReason: null,
+  submittedAt: "2026-04-15",
+  departmentName: "Finance",
+  paymentModeName: "Reimbursement",
+  assignedL1ApproverId: hodId,
+  assignedL2ApproverId: null,
+  submittedBy: "11111111-1111-4111-8111-111111111111",
+  submitter: "Alice Employee",
+  submitterName: "Alice Employee",
+  submitterEmail: "user@nxtwave.co.in",
+  beneficiaryName: null,
+  beneficiaryEmail: null,
+  expense: {
+    id: "expense-1",
+    billNo: "BILL-1",
+    purpose: "Client meeting",
+    expenseCategoryId: "66666666-6666-4666-8666-666666666666",
+    expenseCategoryName: "Travel",
+    productId: "77777777-7777-4777-8777-777777777777",
+    productName: "NxtWave",
+    locationId: "88888888-8888-4888-8888-888888888888",
+    locationName: "Hyderabad",
+    locationType: null,
+    locationDetails: null,
+    transactionDate: "2026-03-14",
+    isGstApplicable: true,
+    gstNumber: "GSTIN-123",
+    basicAmount: 100,
+    cgstAmount: 9,
+    sgstAmount: 9,
+    igstAmount: 0,
+    totalAmount: 118,
+    vendorName: "Vendor",
+    peopleInvolved: null,
+    remarks: null,
+    aiMetadata: {
+      edited_fields: {
+        total_amount: {
+          original: 113,
+        },
+      },
+    },
+    receiptFilePath: null,
+    bankStatementFilePath: null,
+  },
+  advance: null,
 };
 
 function createValidExpenseEditFormData(): FormData {
@@ -317,6 +392,24 @@ describe("claims actions", () => {
       errorMessage: null,
     });
 
+    mockGetClaimDetailById.mockResolvedValue({
+      data: quickViewClaim,
+      errorMessage: null,
+    });
+
+    mockGetClaimAuditLogs.mockResolvedValue({
+      data: [],
+      errorMessage: null,
+    });
+
+    mockGetFinanceApproverIdsForUser.mockResolvedValue({
+      data: [],
+      errorMessage: null,
+    });
+
+    mockGetViewerDepartmentIds.mockResolvedValue([]);
+    mockIsAdmin.mockResolvedValue(false);
+
     mockStorageUpload.mockResolvedValue({
       data: { path: "expenses/user/receipt.pdf" },
       error: null,
@@ -435,6 +528,84 @@ describe("claims actions", () => {
         detailType: "expense",
       }),
     );
+  });
+
+  test("submitClaimAction forwards expense aiMetadata when provided", async () => {
+    const { submitClaimAction } = await import("@/modules/claims/actions");
+
+    const result = await submitClaimAction({
+      ...validExpensePayload,
+      expense: {
+        ...validExpensePayload.expense,
+        aiMetadata: {
+          edited_fields: {
+            total_amount: {
+              original: 113,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({ ok: true, claimId: "claim-1" });
+    expect(mockSubmitExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expense: expect.objectContaining({
+          aiMetadata: {
+            edited_fields: {
+              total_amount: {
+                original: 113,
+              },
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  test("getClaimQuickViewHydrationAction redacts ai metadata for non-finance non-admin viewers", async () => {
+    const { getClaimQuickViewHydrationAction } = await import("@/modules/claims/actions");
+
+    mockGetFinanceApproverIdsForUser.mockResolvedValueOnce({
+      data: [],
+      errorMessage: null,
+    });
+    mockIsAdmin.mockResolvedValueOnce(false);
+
+    const result = await getClaimQuickViewHydrationAction({ claimId: "claim-1" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data.canViewAiMetadata).toBe(false);
+    expect(result.data.claim.expense?.aiMetadata).toBeNull();
+  });
+
+  test("getClaimQuickViewHydrationAction returns ai metadata to finance viewers", async () => {
+    const { getClaimQuickViewHydrationAction } = await import("@/modules/claims/actions");
+
+    mockGetFinanceApproverIdsForUser.mockResolvedValueOnce({
+      data: [{ id: "finance-approver-id" }],
+      errorMessage: null,
+    });
+
+    const result = await getClaimQuickViewHydrationAction({ claimId: "claim-1" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data.canViewAiMetadata).toBe(true);
+    expect(result.data.claim.expense?.aiMetadata).toEqual({
+      edited_fields: {
+        total_amount: {
+          original: 113,
+        },
+      },
+    });
   });
 
   test("submitClaimAction surfaces service errors", async () => {

--- a/tests/unit/claims/approvals-quick-view-sheet.test.tsx
+++ b/tests/unit/claims/approvals-quick-view-sheet.test.tsx
@@ -79,6 +79,7 @@ const hydratedClaim = {
     vendorName: "Foobar Labs",
     peopleInvolved: "Alice, Bob",
     remarks: "Urgent print run",
+    aiMetadata: null,
     receiptFilePath: null,
     bankStatementFilePath: null,
   },
@@ -94,6 +95,7 @@ describe("ApprovalsAuditModeDialog quick view", () => {
       data: {
         claim: hydratedClaim,
         auditLogs: [],
+        canViewAiMetadata: false,
       },
     });
     mockGetClaimFormHydrationAction.mockResolvedValue({
@@ -234,5 +236,113 @@ describe("ApprovalsAuditModeDialog quick view", () => {
     });
 
     expect(screen.queryByText("Quick Edit Claim")).not.toBeInTheDocument();
+  });
+
+  test("renders AI warning when viewer is allowed to see AI metadata", async () => {
+    const user = userEvent.setup();
+    const claimId = "CLAIM-AI-WARNING-TRUE";
+
+    mockGetClaimQuickViewHydrationAction.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        claim: {
+          ...hydratedClaim,
+          id: claimId,
+          expense: hydratedClaim.expense
+            ? {
+                ...hydratedClaim.expense,
+                aiMetadata: {
+                  edited_fields: {
+                    total_amount: {
+                      original: 113,
+                    },
+                  },
+                },
+              }
+            : null,
+        },
+        auditLogs: [],
+        canViewAiMetadata: true,
+      },
+    });
+
+    render(
+      <ApprovalsAuditModeDialog
+        claimId={claimId}
+        detailType="expense"
+        submitter="Jane Doe"
+        amountLabel="₹1,180.00"
+        submissionType="Self"
+        onBehalfEmail={null}
+        expenseReceiptFilePath={null}
+        expenseReceiptSignedUrl={null}
+        expenseBankStatementFilePath={null}
+        expenseBankStatementSignedUrl={null}
+        advanceSupportingDocumentPath={null}
+        advanceSupportingDocumentSignedUrl={null}
+        auditLogs={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /view claim/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("AI originally read: ₹113.00")).toBeInTheDocument();
+    });
+  });
+
+  test("does not render AI warning when viewer is not allowed", async () => {
+    const user = userEvent.setup();
+    const claimId = "CLAIM-AI-WARNING-FALSE";
+
+    mockGetClaimQuickViewHydrationAction.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        claim: {
+          ...hydratedClaim,
+          id: claimId,
+          expense: hydratedClaim.expense
+            ? {
+                ...hydratedClaim.expense,
+                aiMetadata: {
+                  edited_fields: {
+                    total_amount: {
+                      original: 113,
+                    },
+                  },
+                },
+              }
+            : null,
+        },
+        auditLogs: [],
+        canViewAiMetadata: false,
+      },
+    });
+
+    render(
+      <ApprovalsAuditModeDialog
+        claimId={claimId}
+        detailType="expense"
+        submitter="Jane Doe"
+        amountLabel="₹1,180.00"
+        submissionType="Self"
+        onBehalfEmail={null}
+        expenseReceiptFilePath={null}
+        expenseReceiptSignedUrl={null}
+        expenseBankStatementFilePath={null}
+        expenseBankStatementSignedUrl={null}
+        advanceSupportingDocumentPath={null}
+        advanceSupportingDocumentSignedUrl={null}
+        auditLogs={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /view claim/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/AI originally read:/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/claims/submit-claim.service.test.ts
+++ b/tests/unit/claims/submit-claim.service.test.ts
@@ -139,6 +139,41 @@ describe("SubmitClaimService", () => {
     expect(repository.createClaimWithDetail).toHaveBeenCalledTimes(1);
   });
 
+  test("forwards expense ai metadata into create_claim_with_detail payload", async () => {
+    const repository = createRepository();
+    const logger = createLogger();
+    const service = new SubmitClaimService({ repository, logger });
+
+    await service.execute({
+      ...baseInput,
+      expense: {
+        ...baseInput.expense,
+        aiMetadata: {
+          edited_fields: {
+            total_amount: {
+              original: 113,
+            },
+          },
+        },
+      },
+    });
+
+    const createClaimPayload = (repository.createClaimWithDetail as jest.Mock).mock
+      .calls[0]?.[0] as {
+      expense?: {
+        ai_metadata?: unknown;
+      };
+    };
+
+    expect(createClaimPayload.expense?.ai_metadata).toEqual({
+      edited_fields: {
+        total_amount: {
+          original: 113,
+        },
+      },
+    });
+  });
+
   test("accepts petty cash payment mode as expense", async () => {
     const repository = createRepository({
       getPaymentModeById: jest.fn(async () => ({

--- a/tests/unit/claims/supabase-claim-repository.test.ts
+++ b/tests/unit/claims/supabase-claim-repository.test.ts
@@ -55,32 +55,32 @@ describe("SupabaseClaimRepository.getMyClaims", () => {
     jest.clearAllMocks();
   });
 
-  test("normalizes relational join shapes (array/object/null) into flat records", async () => {
+  test("maps enterprise dashboard rows into flat records", async () => {
     const queryBuilder = createQueryBuilder({
       data: [
         {
-          id: "claim-1",
+          claim_id: "claim-1",
           employee_id: "EMP-100",
           on_behalf_email: null,
           submission_type: "Self",
           status: "Submitted - Awaiting HOD approval",
-          submitted_at: "2026-03-14T10:00:00.000Z",
-          master_departments: [{ name: "Finance" }],
-          master_payment_modes: { name: "Reimbursement" },
-          expense_details: { total_amount: "118.25" },
-          advance_details: null,
+          submitted_on: "2026-03-14T10:00:00.000Z",
+          detail_type: "expense",
+          amount: "118.25",
+          department_name: "Finance",
+          type_of_claim: "Reimbursement",
         },
         {
-          id: "claim-2",
+          claim_id: "claim-2",
           employee_id: "EMP-200",
           on_behalf_email: "delegate@nxtwave.co.in",
           submission_type: "On Behalf",
           status: "HOD approved - Awaiting finance approval",
-          submitted_at: "2026-03-13T10:00:00.000Z",
-          master_departments: null,
-          master_payment_modes: [{ name: "Petty Cash Request" }],
-          expense_details: null,
-          advance_details: [{ requested_amount: 500 }],
+          submitted_on: "2026-03-13T10:00:00.000Z",
+          detail_type: "advance",
+          amount: 500,
+          department_name: null,
+          type_of_claim: "Petty Cash Request",
         },
       ],
       error: null,
@@ -199,7 +199,7 @@ describe("SupabaseClaimRepository.getMyClaims", () => {
     });
 
     expect(queryBuilder.or).toHaveBeenCalledWith(
-      "claim_employee_id_raw.ilike.%EMP-050%,on_behalf_employee_code_raw.ilike.%EMP-050%,submitter_email.ilike.%EMP-050%,on_behalf_email.ilike.%EMP-050%",
+      'and(submission_type.eq."Self",claim_employee_id_raw.ilike.%EMP-050%),and(submission_type.eq."On Behalf",on_behalf_employee_code_raw.ilike.%EMP-050%)',
     );
     expect(queryBuilder.ilike).not.toHaveBeenCalledWith("employee_id", "%EMP-050%");
   });
@@ -226,7 +226,7 @@ describe("SupabaseClaimRepository.getMyClaims", () => {
       searchQuery: "claim",
     });
 
-    expect(queryBuilder.ilike).toHaveBeenCalledWith("id", "%claim%");
+    expect(queryBuilder.ilike).toHaveBeenCalledWith("claim_id", "%claim%");
   });
 
   test("applies finance approvals status filter on base status column", async () => {

--- a/tests/unit/claims/supabase-department-viewer-repository.test.ts
+++ b/tests/unit/claims/supabase-department-viewer-repository.test.ts
@@ -185,6 +185,9 @@ describe("SupabaseDepartmentViewerRepository", () => {
         claimId: "claim-2",
         employeeName: "Bob",
         employeeId: "EMP-2",
+        submitterEmail: null,
+        onBehalfEmail: null,
+        onBehalfEmployeeCode: null,
         departmentName: "Engineering",
         typeOfClaim: "Expense",
         amount: 120.5,
@@ -198,10 +201,32 @@ describe("SupabaseDepartmentViewerRepository", () => {
       },
     ]);
     expect(chain.in).toHaveBeenCalledWith("department_id", ["dep-1"]);
-    expect(chain.ilike).toHaveBeenCalledWith("employee_name", "%Bo%");
+    expect(chain.or).toHaveBeenCalledWith(
+      'and(submission_type.eq."Self",submitter_name_raw.ilike.%Bo%),and(submission_type.eq."On Behalf",beneficiary_name_raw.ilike.%Bo%)',
+    );
     expect(chain.eq).toHaveBeenCalledWith("submission_type", "Self");
     expect(chain.gte).toHaveBeenCalledWith("submitted_on", "2026-03-01T00:00:00.000Z");
     expect(chain.lte).toHaveBeenCalledWith("submitted_on", "2026-03-31T23:59:59.999Z");
+  });
+
+  test("getClaims uses partial claim_id search", async () => {
+    const chain = createChain({ data: [], error: null });
+
+    mockFrom.mockReturnValue(chain);
+    mockGetServiceRoleSupabaseClient.mockReturnValue({ from: mockFrom });
+
+    const repository = new SupabaseDepartmentViewerRepository();
+    await repository.getClaims(
+      ["dep-1"],
+      {
+        searchField: "claim_id",
+        searchQuery: "CLAIM",
+      },
+      { cursor: null, limit: 10 },
+    );
+
+    expect(chain.ilike).toHaveBeenCalledWith("claim_id", "%CLAIM%");
+    expect(chain.eq).not.toHaveBeenCalledWith("claim_id", "CLAIM");
   });
 
   test("getClaims uses raw employee identity OR filter for employee_id search", async () => {
@@ -221,7 +246,7 @@ describe("SupabaseDepartmentViewerRepository", () => {
     );
 
     expect(chain.or).toHaveBeenCalledWith(
-      "claim_employee_id_raw.ilike.%EMP-009%,on_behalf_employee_code_raw.ilike.%EMP-009%,submitter_email.ilike.%EMP-009%,on_behalf_email.ilike.%EMP-009%",
+      'and(submission_type.eq."Self",claim_employee_id_raw.ilike.%EMP-009%),and(submission_type.eq."On Behalf",on_behalf_employee_code_raw.ilike.%EMP-009%)',
     );
     expect(chain.ilike).not.toHaveBeenCalledWith("employee_id", "%EMP-009%");
   });


### PR DESCRIPTION
- Introduced ClaimExpenseAiOriginalValue and ClaimExpenseAiMetadata types to handle AI-generated metadata.
- Updated ClaimSubmissionInput to include aiMetadata for expense claims.
- Enhanced the SupabaseClaimRepository to store and retrieve AI metadata.
- Implemented logic to parse and normalize AI metadata in the claims actions.
- Modified UI components to display AI warnings based on user permissions.
- Added new functions to handle AI metadata in the new claim form.
- Updated validation schemas to include AI metadata.
- Created database migration to add ai_metadata column to expense_details table and updated the create_claim_with_detail function.
- Added unit tests to ensure proper handling of AI metadata in claims actions and UI components.