### PR TITLE
feat(claims): add email placeholder and validation for on-behalf subm…

### DIFF
--- a/src/modules/claims/ui/new-claim-form-client.tsx
+++ b/src/modules/claims/ui/new-claim-form-client.tsx
@@ -26,7 +26,10 @@ import {
   type CurrentUserHydration,
 } from "@/modules/claims/actions";
 import { parseReceiptAction } from "@/modules/claims/actions/parse-receipt";
-import { newClaimSubmitSchema } from "@/modules/claims/validators/new-claim-schema";
+import {
+  newClaimSubmitSchema,
+  ON_BEHALF_EMAIL_DOMAIN,
+} from "@/modules/claims/validators/new-claim-schema";
 import { computeForeignTotal, computeInrTotal } from "@/modules/claims/utils/compute-totals";
 import { useClaimFormAutofill } from "@/hooks/use-claim-form-autofill";
 import {
@@ -1434,7 +1437,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
                   <FormInput
                     id="onBehalfEmail"
                     type="email"
-                    placeholder="e.g., user@nxtwave.co.in"
+                    placeholder={`e.g., user${ON_BEHALF_EMAIL_DOMAIN}`}
                     className="h-9 rounded-lg border border-zinc-300 px-3 text-sm"
                     {...register("onBehalfEmail", {
                       setValueAs: (value) => toNullable(String(value ?? "")),

--- a/src/modules/claims/ui/new-claim-form-client.tsx
+++ b/src/modules/claims/ui/new-claim-form-client.tsx
@@ -1434,6 +1434,7 @@ export function NewClaimFormClient({ currentUser, options }: NewClaimFormClientP
                   <FormInput
                     id="onBehalfEmail"
                     type="email"
+                    placeholder="e.g., user@nxtwave.co.in"
                     className="h-9 rounded-lg border border-zinc-300 px-3 text-sm"
                     {...register("onBehalfEmail", {
                       setValueAs: (value) => toNullable(String(value ?? "")),

--- a/src/modules/claims/validators/new-claim-schema.ts
+++ b/src/modules/claims/validators/new-claim-schema.ts
@@ -171,6 +171,12 @@ export const newClaimSubmitSchema = z
           message: "Enter a valid on-behalf email.",
           path: ["onBehalfEmail"],
         });
+      } else if (!value.onBehalfEmail?.endsWith("@nxtwave.co.in")) {
+        context.addIssue({
+          code: "custom",
+          message: "Only @nxtwave.co.in emails are allowed for On Behalf submissions.",
+          path: ["onBehalfEmail"],
+        });
       }
 
       if (onBehalfEmployeeCodeIsNA) {

--- a/src/modules/claims/validators/new-claim-schema.ts
+++ b/src/modules/claims/validators/new-claim-schema.ts
@@ -4,6 +4,8 @@ import { LOCATION_TYPES } from "@/core/constants/location-types";
 const uuidSchema = z.uuid("Invalid UUID value");
 const emailSchema = z.email("Enter a valid on-behalf email");
 
+export const ON_BEHALF_EMAIL_DOMAIN = "@nxtwave.co.in";
+
 const optionalTextToNA = z.preprocess(
   (value) => (value === null ? undefined : value),
   z
@@ -171,10 +173,10 @@ export const newClaimSubmitSchema = z
           message: "Enter a valid on-behalf email.",
           path: ["onBehalfEmail"],
         });
-      } else if (!value.onBehalfEmail?.endsWith("@nxtwave.co.in")) {
+      } else if (!value.onBehalfEmail.toLowerCase().endsWith(ON_BEHALF_EMAIL_DOMAIN)) {
         context.addIssue({
           code: "custom",
-          message: "Only @nxtwave.co.in emails are allowed for On Behalf submissions.",
+          message: `Only ${ON_BEHALF_EMAIL_DOMAIN} emails are allowed for On Behalf submissions.`,
           path: ["onBehalfEmail"],
         });
       }

--- a/tests/unit/claims/new-claim-schema.test.ts
+++ b/tests/unit/claims/new-claim-schema.test.ts
@@ -164,3 +164,57 @@ describe("newClaimSubmitSchema", () => {
     }
   });
 });
+
+describe("newClaimSubmitSchema – On Behalf email domain", () => {
+  const onBehalfPayload = (onBehalfEmail: string) => ({
+    ...validExpensePayload,
+    submissionType: "On Behalf" as const,
+    onBehalfEmail,
+    onBehalfEmployeeCode: "EMP-200",
+  });
+
+  test("accepts an On Behalf email whose @nxtwave.co.in domain is uppercase", () => {
+    const parsed = newClaimSubmitSchema.safeParse(onBehalfPayload("user@NXTWAVE.CO.IN"));
+
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts a lowercase @nxtwave.co.in On Behalf email", () => {
+    const parsed = newClaimSubmitSchema.safeParse(onBehalfPayload("user@nxtwave.co.in"));
+
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects an On Behalf email on a .tech domain", () => {
+    const parsed = newClaimSubmitSchema.safeParse(onBehalfPayload("user@nxtwave.tech"));
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.flatten().fieldErrors.onBehalfEmail).toContain(
+        "Only @nxtwave.co.in emails are allowed for On Behalf submissions.",
+      );
+    }
+  });
+
+  test("rejects an On Behalf email on an external domain", () => {
+    const parsed = newClaimSubmitSchema.safeParse(onBehalfPayload("user@gmail.com"));
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.flatten().fieldErrors.onBehalfEmail).toContain(
+        "Only @nxtwave.co.in emails are allowed for On Behalf submissions.",
+      );
+    }
+  });
+
+  test("rejects a look-alike domain that lacks the @nxtwave.co.in boundary", () => {
+    const parsed = newClaimSubmitSchema.safeParse(onBehalfPayload("user@evilnxtwave.co.in"));
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.flatten().fieldErrors.onBehalfEmail).toContain(
+        "Only @nxtwave.co.in emails are allowed for On Behalf submissions.",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What

Restrict the **On Behalf** claim submission email to the `@nxtwave.co.in` domain (an allowlist — anything else, e.g. `.tech`, `gmail.com`, or look-alike domains, is rejected).

## Changes

- **Validation:** `onBehalfEmail` must end with `@nxtwave.co.in` for On Behalf submissions. The check is **case-insensitive** (`user@NXTWAVE.CO.IN` is accepted) and enforced in `newClaimSubmitSchema`, which runs on **both the client form and the server action** (`actions.ts`).
- **UX:** added an `e.g., user@nxtwave.co.in` placeholder on the email input.
- **Maintainability:** domain is a single source of truth via `ON_BEHALF_EMAIL_DOMAIN`, shared by the validator, the error message, and the placeholder.
- **Tests:** unit coverage in `new-claim-schema.test.ts` — upper/lower-case `@nxtwave.co.in` accepted; `.tech`, external, and look-alike domains (e.g. `evilnxtwave.co.in`) rejected.

## Notes

- This is an **allowlist**, not a blocklist — it inherently blocks `.tech` and every non-`nxtwave.co.in` domain.
- Sub-domain mailboxes (e.g. `user@team.nxtwave.co.in`) are intentionally rejected; these are not used.