### PR TITLE
fix(dashboard): claim row fan-out + delete modal portal (also merges bc_int migrations into development)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,8 @@
       "PowerShell(New-Item *)",
       "Skill(superpowers:using-superpowers)",
       "Bash(git *)",
-      "Bash(npx *)"
+      "Bash(npx *)",
+      "PowerShell(Get-ChildItem \"d:\\\\nxtclaim\" -Name | Where-Object { $_ -match \"eslint|prettier|biome\" })"
     ]
   },
   "enabledMcpjsonServers": ["filesystem", "supabase"],

--- a/src/modules/claims/ui/delete-claim-button.tsx
+++ b/src/modules/claims/ui/delete-claim-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { AlertTriangle } from "lucide-react";
+import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { deleteClaimAction } from "@/modules/claims/actions";
 
@@ -62,6 +63,60 @@ export function DeleteClaimButton({
     });
   };
 
+  const modal = isModalOpen ? (
+    <div
+      className="fixed inset-0 z-[260] bg-zinc-950/50 backdrop-blur-sm"
+      onClick={handleModalClose}
+    >
+      <div className="flex min-h-full items-center justify-center">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-claim-title"
+          aria-describedby="delete-claim-description"
+          className="mx-4 w-full max-w-md rounded-2xl border border-zinc-200 bg-white p-6 text-center shadow-2xl dark:border-zinc-800 dark:bg-zinc-900"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="mx-auto mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-400">
+            <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+          </div>
+
+          <h2
+            id="delete-claim-title"
+            className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+          >
+            Delete Claim
+          </h2>
+          <p
+            id="delete-claim-description"
+            className="mx-auto mt-2 max-w-sm text-sm text-zinc-500 dark:text-zinc-400"
+          >
+            Are you sure you want to delete this claim? This action will remove it from your queue.
+          </p>
+
+          <div className="mt-6 flex flex-row gap-3">
+            <button
+              type="button"
+              onClick={handleModalClose}
+              disabled={isPending}
+              className="inline-flex h-10 flex-1 items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 text-sm font-semibold text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-900"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmDelete}
+              disabled={isPending}
+              className="inline-flex h-10 flex-1 items-center justify-center rounded-xl border border-transparent bg-rose-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? "Deleting..." : "Delete"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <>
       <button
@@ -77,60 +132,7 @@ export function DeleteClaimButton({
         {isPending ? "Deleting..." : "Delete Claim"}
       </button>
 
-      {isModalOpen ? (
-        <div
-          className="fixed inset-0 z-50 bg-zinc-950/50 backdrop-blur-sm"
-          onClick={handleModalClose}
-        >
-          <div className="flex min-h-full items-center justify-center">
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="delete-claim-title"
-              aria-describedby="delete-claim-description"
-              className="mx-4 w-full max-w-md rounded-2xl border border-zinc-200 bg-white p-6 text-center shadow-2xl dark:border-zinc-800 dark:bg-zinc-900"
-              onClick={(event) => event.stopPropagation()}
-            >
-              <div className="mx-auto mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-400">
-                <AlertTriangle className="h-5 w-5" aria-hidden="true" />
-              </div>
-
-              <h2
-                id="delete-claim-title"
-                className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
-              >
-                Delete Claim
-              </h2>
-              <p
-                id="delete-claim-description"
-                className="mx-auto mt-2 max-w-sm text-sm text-zinc-500 dark:text-zinc-400"
-              >
-                Are you sure you want to delete this claim? This action will remove it from your
-                queue.
-              </p>
-
-              <div className="mt-6 flex flex-row gap-3">
-                <button
-                  type="button"
-                  onClick={handleModalClose}
-                  disabled={isPending}
-                  className="inline-flex h-10 flex-1 items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 text-sm font-semibold text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-900"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmDelete}
-                  disabled={isPending}
-                  className="inline-flex h-10 flex-1 items-center justify-center rounded-xl border border-transparent bg-rose-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {isPending ? "Deleting..." : "Delete"}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      {typeof document !== "undefined" && modal ? createPortal(modal, document.body) : null}
     </>
   );
 }

--- a/supabase/migrations/20260519140000_bc_payload_add_amount_fields.sql
+++ b/supabase/migrations/20260519140000_bc_payload_add_amount_fields.sql
@@ -1,0 +1,90 @@
+-- Extend get_bc_claim_payload to return the four amount columns BC now consumes:
+--   basic_amount, total_amount, foreign_basic_amount, foreign_total_amount
+-- The edge function payload builder picks the right pair per vendor / non-vendor:
+--   vendor     → amountLc = basic_amount,  amount = foreign_basic_amount
+--   non-vendor → amountLc = total_amount,  amount = foreign_total_amount (falls back to total_amount when 0)
+
+CREATE OR REPLACE FUNCTION public.get_bc_claim_payload(p_claim_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_already_submitted_id UUID;
+  v_payment_mode_name    TEXT;
+  v_result               JSONB;
+BEGIN
+  SELECT c.bc_claim_details_id, mpm.name
+    INTO v_already_submitted_id, v_payment_mode_name
+  FROM public.claims c
+  JOIN public.master_payment_modes mpm ON mpm.id = c.payment_mode_id
+  WHERE c.id = p_claim_id AND c.is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CLAIM_NOT_FOUND: %', p_claim_id USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_already_submitted_id IS NOT NULL THEN
+    RAISE EXCEPTION 'ALREADY_SUBMITTED: %', v_already_submitted_id USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'claim_id',                     c.id,
+    'payment_mode_name',            v_payment_mode_name,
+    'submission_type',              c.submission_type,
+    'employee_id',                  c.employee_id,
+    'on_behalf_employee_code',      c.on_behalf_employee_code,
+    'employee_name',
+      CASE WHEN c.submission_type = 'On_behalf'
+           THEN COALESCE(onbehalf.full_name, '')
+           ELSE COALESCE(submitter.full_name, '')
+      END,
+    'program_code',                 ppm.program_code,
+    'sub_product_code',             spm.sub_product_code,
+    'responsible_department_code',  drm.responsible_department_code,
+    'beneficiary_department_code',  drm.beneficiary_department_code,
+    'region_code',                  elm.region_code,
+    'bill_no',                      ed.bill_no,
+    'transaction_date',             ed.transaction_date,
+    'purpose',                      ed.purpose,
+    'receipt_file_path',            ed.receipt_file_path,
+    'bank_statement_file_path',     ed.bank_statement_file_path,
+    'bc_code',                      ecm.bc_code,
+    'basic_amount',                 ed.basic_amount,
+    'total_amount',                 ed.total_amount,
+    'foreign_basic_amount',         COALESCE(ed.foreign_basic_amount, 0),
+    'foreign_total_amount',         COALESCE(ed.foreign_total_amount, 0)
+  )
+  INTO v_result
+  FROM public.claims c
+  JOIN public.expense_details ed                    ON ed.claim_id = c.id AND ed.is_active = true
+  JOIN public.users submitter                       ON submitter.id = c.submitted_by
+  LEFT JOIN public.users onbehalf                   ON onbehalf.id = c.on_behalf_of_id
+  JOIN public.expense_category_bc_mappings ecm      ON ecm.expense_category_id = ed.expense_category_id AND ecm.is_active = true
+  JOIN LATERAL (
+    SELECT program_code FROM public.master_program_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) ppm ON true
+  JOIN LATERAL (
+    SELECT sub_product_code FROM public.master_sub_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) spm ON true
+  JOIN LATERAL (
+    SELECT responsible_department_code, beneficiary_department_code
+    FROM public.master_department_responsible_mappings
+    WHERE department_id = c.department_id AND is_active = true LIMIT 1
+  ) drm ON true
+  JOIN LATERAL (
+    SELECT region_code FROM public.master_expense_location_mappings
+    WHERE location_id = ed.location_id AND is_active = true LIMIT 1
+  ) elm ON true
+  WHERE c.id = p_claim_id;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'MISSING_MAPPING: one or more required mappings missing for claim %', p_claim_id
+      USING ERRCODE = 'P0003';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;

--- a/supabase/migrations/20260520000000_claim_submission_type_enum.sql
+++ b/supabase/migrations/20260520000000_claim_submission_type_enum.sql
@@ -1,0 +1,303 @@
+-- Convert claims.submission_type from text → enum so the vocabulary is
+-- schema-enforced (TypeScript types narrow to "Self" | "On Behalf"), and
+-- fix get_bc_claim_payload to compare against the correct literal.
+--
+-- Pre-migration audit (verified 2026-05-19):
+--   distinct values in 4,529 rows: only 'Self' (3,400) and 'On Behalf' (1,129)
+--   no NULLs, no whitespace anomalies, no indexes on submission_type
+--   views referencing the column: vw_admin_claims_dashboard, vw_enterprise_claims_dashboard
+--   CHECK constraints: claims_submission_type_check (simple IN), claims_on_behalf_fields (cross-field)
+--   only get_bc_claim_payload uses the wrong 'On_behalf' literal
+
+BEGIN;
+
+-- 1. Drop dependent views (must drop before ALTER COLUMN TYPE).
+DROP VIEW public.vw_admin_claims_dashboard;
+DROP VIEW public.vw_enterprise_claims_dashboard;
+
+-- 2. Drop CHECK constraints (will recreate with enum-aware comparisons).
+ALTER TABLE public.claims DROP CONSTRAINT IF EXISTS claims_submission_type_check;
+ALTER TABLE public.claims DROP CONSTRAINT IF EXISTS claims_on_behalf_fields;
+
+-- 3. Create enum type.
+CREATE TYPE public.claim_submission_type AS ENUM ('Self', 'On Behalf');
+
+-- 4. Alter column type. Cast via text to enum; rows already match enum members.
+ALTER TABLE public.claims
+  ALTER COLUMN submission_type TYPE public.claim_submission_type
+  USING submission_type::text::public.claim_submission_type;
+
+-- 5. Recreate cross-field check using the enum.
+ALTER TABLE public.claims ADD CONSTRAINT claims_on_behalf_fields CHECK (
+  (
+    submission_type = 'Self'::claim_submission_type
+    AND COALESCE(on_behalf_email, 'N/A') = 'N/A'
+    AND COALESCE(on_behalf_employee_code, 'N/A') = 'N/A'
+    AND on_behalf_of_id = submitted_by
+  )
+  OR
+  (
+    submission_type = 'On Behalf'::claim_submission_type
+    AND COALESCE(on_behalf_email, 'N/A') <> 'N/A'
+    AND COALESCE(on_behalf_employee_code, 'N/A') <> 'N/A'
+    AND on_behalf_of_id IS NOT NULL
+  )
+);
+
+-- 6. Recreate vw_admin_claims_dashboard (definition captured verbatim from pg_get_viewdef(); security_invoker added explicitly because pg_get_viewdef() does not emit view options).
+CREATE VIEW public.vw_admin_claims_dashboard WITH (security_invoker = 'on') AS
+ SELECT c.id AS claim_id,
+    COALESCE(NULLIF(TRIM(BOTH FROM u.full_name), ''::text), NULLIF(TRIM(BOTH FROM split_part(u.email, '@'::text, 1)), ''::text), NULLIF(TRIM(BOTH FROM c.employee_id), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_email), ''::text), 'N/A'::text) AS employee_name,
+    COALESCE(NULLIF(TRIM(BOTH FROM c.employee_id), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_employee_code), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_email), ''::text), NULLIF(TRIM(BOTH FROM u.email), ''::text), 'N/A'::text) AS employee_id,
+    c.employee_id AS claim_employee_id_raw,
+    c.on_behalf_employee_code AS on_behalf_employee_code_raw,
+    NULLIF(TRIM(BOTH FROM u.full_name), ''::text) AS submitter_name_raw,
+    NULLIF(TRIM(BOTH FROM beneficiary.full_name), ''::text) AS beneficiary_name_raw,
+    COALESCE(NULLIF(TRIM(BOTH FROM md.name), ''::text), 'Unknown Department'::text) AS department_name,
+    COALESCE(NULLIF(TRIM(BOTH FROM mpm.name), ''::text),
+        CASE
+            WHEN c.detail_type = 'advance'::text THEN 'Advance'::text
+            WHEN c.detail_type = 'expense'::text THEN 'Expense'::text
+            ELSE 'Unknown'::text
+        END) AS type_of_claim,
+    COALESCE(ed.total_amount, ad.total_amount, 0::numeric)::numeric(14,2) AS amount,
+    c.status,
+    COALESCE(c.submitted_at, c.created_at) AS submitted_on,
+    COALESCE(c.hod_action_at,
+        CASE
+            WHEN c.status = 'HOD approved - Awaiting finance approval'::claim_status THEN c.updated_at
+            WHEN (c.status = ANY (ARRAY['Rejected - Resubmission Not Allowed'::claim_status, 'Rejected - Resubmission Allowed'::claim_status])) AND c.assigned_l2_approver_id IS NULL THEN c.updated_at
+            ELSE NULL::timestamp with time zone
+        END) AS hod_action_date,
+    COALESCE(c.finance_action_at,
+        CASE
+            WHEN c.status = ANY (ARRAY['Finance Approved - Payment under process'::claim_status, 'Payment Done - Closed'::claim_status]) THEN c.updated_at
+            WHEN (c.status = ANY (ARRAY['Rejected - Resubmission Not Allowed'::claim_status, 'Rejected - Resubmission Allowed'::claim_status])) AND c.assigned_l2_approver_id IS NOT NULL THEN c.updated_at
+            ELSE NULL::timestamp with time zone
+        END) AS finance_action_date,
+    COALESCE(ed.location_id, ad.location_id) AS location_id,
+    COALESCE(ed.product_id, ad.product_id) AS product_id,
+    ed.expense_category_id,
+    c.submitted_by,
+    c.on_behalf_of_id,
+    c.on_behalf_email,
+    c.assigned_l1_approver_id,
+    c.assigned_l2_approver_id,
+    c.department_id,
+    c.payment_mode_id,
+    c.detail_type,
+    c.submission_type,
+    c.is_active,
+    c.created_at,
+    c.updated_at,
+    c.deleted_by,
+    c.deleted_at,
+    NULLIF(TRIM(BOTH FROM deleted_by_user.full_name), ''::text) AS deleted_by_name,
+        CASE
+            WHEN c.deleted_by IS NULL THEN NULL::text
+            WHEN (EXISTS ( SELECT 1
+               FROM admins a
+              WHERE a.user_id = c.deleted_by)) THEN 'admin'::text
+            WHEN (EXISTS ( SELECT 1
+               FROM master_finance_approvers f
+              WHERE f.user_id = c.deleted_by AND f.is_active = true)) THEN 'finance'::text
+            ELSE 'employee'::text
+        END AS deleted_by_role,
+    u.email AS submitter_email,
+    hod.email AS hod_email,
+    finance.email AS finance_email,
+        CASE
+            WHEN NULLIF(TRIM(BOTH FROM u.full_name), ''::text) IS NOT NULL AND NULLIF(TRIM(BOTH FROM u.email), ''::text) IS NOT NULL THEN ((TRIM(BOTH FROM u.full_name) || ' ('::text) || TRIM(BOTH FROM u.email)) || ')'::text
+            WHEN NULLIF(TRIM(BOTH FROM u.full_name), ''::text) IS NOT NULL THEN TRIM(BOTH FROM u.full_name)
+            WHEN NULLIF(TRIM(BOTH FROM u.email), ''::text) IS NOT NULL THEN TRIM(BOTH FROM u.email)
+            ELSE c.employee_id
+        END AS submitter_label,
+        CASE
+            WHEN c.detail_type = 'expense'::text THEN COALESCE(NULLIF(TRIM(BOTH FROM mec_name.name), ''::text), 'Uncategorized'::text)
+            ELSE 'Advance'::text
+        END AS category_name,
+    COALESCE(ed.purpose, ad.purpose) AS purpose,
+    ed.receipt_file_path,
+    ed.bank_statement_file_path,
+    ad.supporting_document_path,
+    c.bc_claim_details_id,
+    COALESCE(bcd.is_vendor_payment, false) AS is_vendor_payment
+   FROM claims c
+     LEFT JOIN users u ON u.id = c.submitted_by
+     LEFT JOIN users beneficiary ON beneficiary.id = c.on_behalf_of_id
+     LEFT JOIN users hod ON hod.id = c.assigned_l1_approver_id
+     LEFT JOIN users finance ON finance.id = c.assigned_l2_approver_id
+     LEFT JOIN users deleted_by_user ON deleted_by_user.id = c.deleted_by
+     LEFT JOIN master_departments md ON md.id = c.department_id
+     LEFT JOIN master_payment_modes mpm ON mpm.id = c.payment_mode_id
+     LEFT JOIN expense_details ed ON ed.claim_id = c.id
+     LEFT JOIN master_expense_categories mec_name ON mec_name.id = ed.expense_category_id
+     LEFT JOIN advance_details ad ON ad.claim_id = c.id
+     LEFT JOIN bc_claim_details bcd ON bcd.claim_id = c.id;
+
+-- 7. Recreate vw_enterprise_claims_dashboard (definition captured verbatim from pg_get_viewdef(); security_invoker added explicitly because pg_get_viewdef() does not emit view options).
+CREATE VIEW public.vw_enterprise_claims_dashboard WITH (security_invoker = 'on') AS
+ SELECT c.id AS claim_id,
+    COALESCE(NULLIF(TRIM(BOTH FROM u.full_name), ''::text), NULLIF(TRIM(BOTH FROM split_part(u.email, '@'::text, 1)), ''::text), NULLIF(TRIM(BOTH FROM c.employee_id), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_email), ''::text), 'N/A'::text) AS employee_name,
+    COALESCE(NULLIF(TRIM(BOTH FROM c.employee_id), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_employee_code), ''::text), NULLIF(TRIM(BOTH FROM c.on_behalf_email), ''::text), NULLIF(TRIM(BOTH FROM u.email), ''::text), 'N/A'::text) AS employee_id,
+    c.employee_id AS claim_employee_id_raw,
+    c.on_behalf_employee_code AS on_behalf_employee_code_raw,
+    NULLIF(TRIM(BOTH FROM u.full_name), ''::text) AS submitter_name_raw,
+    NULLIF(TRIM(BOTH FROM beneficiary.full_name), ''::text) AS beneficiary_name_raw,
+    COALESCE(NULLIF(TRIM(BOTH FROM md.name), ''::text), 'Unknown Department'::text) AS department_name,
+    COALESCE(NULLIF(TRIM(BOTH FROM mpm.name), ''::text),
+        CASE
+            WHEN c.detail_type = 'advance'::text THEN 'Advance'::text
+            WHEN c.detail_type = 'expense'::text THEN 'Expense'::text
+            ELSE 'Unknown'::text
+        END) AS type_of_claim,
+    COALESCE(ed.total_amount, ad.total_amount, 0::numeric)::numeric(14,2) AS amount,
+    c.status,
+    COALESCE(c.submitted_at, c.created_at) AS submitted_on,
+    COALESCE(c.hod_action_at,
+        CASE
+            WHEN c.status = 'HOD approved - Awaiting finance approval'::claim_status THEN c.updated_at
+            WHEN (c.status = ANY (ARRAY['Rejected - Resubmission Not Allowed'::claim_status, 'Rejected - Resubmission Allowed'::claim_status])) AND c.assigned_l2_approver_id IS NULL THEN c.updated_at
+            ELSE NULL::timestamp with time zone
+        END) AS hod_action_date,
+    COALESCE(c.finance_action_at,
+        CASE
+            WHEN c.status = ANY (ARRAY['Finance Approved - Payment under process'::claim_status, 'Payment Done - Closed'::claim_status]) THEN c.updated_at
+            WHEN (c.status = ANY (ARRAY['Rejected - Resubmission Not Allowed'::claim_status, 'Rejected - Resubmission Allowed'::claim_status])) AND c.assigned_l2_approver_id IS NOT NULL THEN c.updated_at
+            ELSE NULL::timestamp with time zone
+        END) AS finance_action_date,
+    COALESCE(ed.location_id, ad.location_id) AS location_id,
+    COALESCE(ed.product_id, ad.product_id) AS product_id,
+    ed.expense_category_id,
+    c.submitted_by,
+    c.on_behalf_of_id,
+    c.on_behalf_email,
+    c.assigned_l1_approver_id,
+    c.assigned_l2_approver_id,
+    c.department_id,
+    c.payment_mode_id,
+    c.detail_type,
+    c.submission_type,
+    c.is_active,
+    c.created_at,
+    c.updated_at,
+    u.email AS submitter_email,
+    hod.email AS hod_email,
+    finance.email AS finance_email,
+        CASE
+            WHEN NULLIF(TRIM(BOTH FROM u.full_name), ''::text) IS NOT NULL AND NULLIF(TRIM(BOTH FROM u.email), ''::text) IS NOT NULL THEN ((TRIM(BOTH FROM u.full_name) || ' ('::text) || TRIM(BOTH FROM u.email)) || ')'::text
+            WHEN NULLIF(TRIM(BOTH FROM u.full_name), ''::text) IS NOT NULL THEN TRIM(BOTH FROM u.full_name)
+            WHEN NULLIF(TRIM(BOTH FROM u.email), ''::text) IS NOT NULL THEN TRIM(BOTH FROM u.email)
+            ELSE c.employee_id
+        END AS submitter_label,
+        CASE
+            WHEN c.detail_type = 'expense'::text THEN COALESCE(NULLIF(TRIM(BOTH FROM mec_name.name), ''::text), 'Uncategorized'::text)
+            ELSE 'Advance'::text
+        END AS category_name,
+    COALESCE(ed.purpose, ad.purpose) AS purpose,
+    ed.receipt_file_path,
+    ed.bank_statement_file_path,
+    ad.supporting_document_path,
+    c.bc_claim_details_id,
+    COALESCE(bcd.is_vendor_payment, false) AS is_vendor_payment
+   FROM claims c
+     LEFT JOIN users u ON u.id = c.submitted_by
+     LEFT JOIN users beneficiary ON beneficiary.id = c.on_behalf_of_id
+     LEFT JOIN users hod ON hod.id = c.assigned_l1_approver_id
+     LEFT JOIN users finance ON finance.id = c.assigned_l2_approver_id
+     LEFT JOIN master_departments md ON md.id = c.department_id
+     LEFT JOIN master_payment_modes mpm ON mpm.id = c.payment_mode_id
+     LEFT JOIN expense_details ed ON ed.claim_id = c.id AND ed.is_active = true
+     LEFT JOIN master_expense_categories mec_name ON mec_name.id = ed.expense_category_id
+     LEFT JOIN advance_details ad ON ad.claim_id = c.id AND ad.is_active = true
+     LEFT JOIN bc_claim_details bcd ON bcd.claim_id = c.id
+  WHERE c.is_active = true;
+
+-- 8. Recreate get_bc_claim_payload using the corrected literal.
+--    All other parts of the function body are unchanged from migration 20260519140000.
+CREATE OR REPLACE FUNCTION public.get_bc_claim_payload(p_claim_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_already_submitted_id UUID;
+  v_payment_mode_name    TEXT;
+  v_result               JSONB;
+BEGIN
+  SELECT c.bc_claim_details_id, mpm.name
+    INTO v_already_submitted_id, v_payment_mode_name
+  FROM public.claims c
+  JOIN public.master_payment_modes mpm ON mpm.id = c.payment_mode_id
+  WHERE c.id = p_claim_id AND c.is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CLAIM_NOT_FOUND: %', p_claim_id USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_already_submitted_id IS NOT NULL THEN
+    RAISE EXCEPTION 'ALREADY_SUBMITTED: %', v_already_submitted_id USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'claim_id',                     c.id,
+    'payment_mode_name',            v_payment_mode_name,
+    'submission_type',              c.submission_type,
+    'employee_id',                  c.employee_id,
+    'on_behalf_employee_code',      c.on_behalf_employee_code,
+    'employee_name',
+      CASE WHEN c.submission_type = 'On Behalf'::claim_submission_type
+           THEN COALESCE(onbehalf.full_name, '')
+           ELSE COALESCE(submitter.full_name, '')
+      END,
+    'program_code',                 ppm.program_code,
+    'sub_product_code',             spm.sub_product_code,
+    'responsible_department_code',  drm.responsible_department_code,
+    'beneficiary_department_code',  drm.beneficiary_department_code,
+    'region_code',                  elm.region_code,
+    'bill_no',                      ed.bill_no,
+    'transaction_date',             ed.transaction_date,
+    'purpose',                      ed.purpose,
+    'receipt_file_path',            ed.receipt_file_path,
+    'bank_statement_file_path',     ed.bank_statement_file_path,
+    'bc_code',                      ecm.bc_code,
+    'basic_amount',                 ed.basic_amount,
+    'total_amount',                 ed.total_amount,
+    'foreign_basic_amount',         COALESCE(ed.foreign_basic_amount, 0),
+    'foreign_total_amount',         COALESCE(ed.foreign_total_amount, 0)
+  )
+  INTO v_result
+  FROM public.claims c
+  JOIN public.expense_details ed                    ON ed.claim_id = c.id AND ed.is_active = true
+  JOIN public.users submitter                       ON submitter.id = c.submitted_by
+  LEFT JOIN public.users onbehalf                   ON onbehalf.id = c.on_behalf_of_id
+  JOIN public.expense_category_bc_mappings ecm      ON ecm.expense_category_id = ed.expense_category_id AND ecm.is_active = true
+  JOIN LATERAL (
+    SELECT program_code FROM public.master_program_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) ppm ON true
+  JOIN LATERAL (
+    SELECT sub_product_code FROM public.master_sub_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) spm ON true
+  JOIN LATERAL (
+    SELECT responsible_department_code, beneficiary_department_code
+    FROM public.master_department_responsible_mappings
+    WHERE department_id = c.department_id AND is_active = true LIMIT 1
+  ) drm ON true
+  JOIN LATERAL (
+    SELECT region_code FROM public.master_expense_location_mappings
+    WHERE location_id = ed.location_id AND is_active = true LIMIT 1
+  ) elm ON true
+  WHERE c.id = p_claim_id;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'MISSING_MAPPING: one or more required mappings missing for claim %', p_claim_id
+      USING ERRCODE = 'P0003';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260520010000_restore_security_invoker_on_enum_views.sql
+++ b/supabase/migrations/20260520010000_restore_security_invoker_on_enum_views.sql
@@ -1,0 +1,11 @@
+-- Migration 20260520000000_claim_submission_type_enum.sql dropped + recreated
+-- vw_admin_claims_dashboard and vw_enterprise_claims_dashboard using CREATE VIEW
+-- without the WITH (security_invoker = 'on') option, silently undoing the fix
+-- from 20260519110000_restore_view_security_invoker.sql.
+--
+-- This migration restores security_invoker on the live views in NxtClaimTest.
+-- Future fresh DB restores already have the option baked into 20260520000000
+-- (amended in the same commit as this migration).
+
+ALTER VIEW public.vw_admin_claims_dashboard SET (security_invoker = on);
+ALTER VIEW public.vw_enterprise_claims_dashboard SET (security_invoker = on);

--- a/supabase/migrations/20260520020000_bc_functions_set_search_path.sql
+++ b/supabase/migrations/20260520020000_bc_functions_set_search_path.sql
@@ -1,0 +1,19 @@
+-- Pin search_path on the four BC SECURITY DEFINER functions. Without an
+-- explicit search_path a SECURITY DEFINER function runs with the caller's
+-- search_path, which lets a caller shadow unqualified references via a
+-- malicious schema. We set "public, pg_temp": public is required because
+-- get_bc_claim_payload casts to the unqualified type claim_submission_type
+-- (resolved via public), and pg_temp is pinned LAST so temp objects can't
+-- shadow real ones. The function bodies are unchanged (ALTER, not recreate).
+
+ALTER FUNCTION public.get_bc_claim_payload(text)
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.start_bc_claim_attempt(text, boolean, jsonb)
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.complete_bc_claim(uuid, uuid, jsonb)
+  SET search_path = public, pg_temp;
+
+ALTER FUNCTION public.record_bc_claim_failure(uuid, uuid, jsonb)
+  SET search_path = public, pg_temp;

--- a/supabase/migrations/20260520030000_bc_functions_revoke_anon_execute.sql
+++ b/supabase/migrations/20260520030000_bc_functions_revoke_anon_execute.sql
@@ -1,0 +1,18 @@
+-- Lock down the BC SECURITY DEFINER functions so only service_role (used by
+-- the edge functions) may execute them. They were executable by anon and
+-- authenticated via Supabase defaults; because they are SECURITY DEFINER they
+-- bypass RLS, so anon/authenticated execute access could expose claim data.
+-- No app-side code calls these as anon/authenticated (only the edge functions
+-- via the service-role key), so revoking is safe.
+
+REVOKE EXECUTE ON FUNCTION public.get_bc_claim_payload(text) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.get_bc_claim_payload(text) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.start_bc_claim_attempt(text, boolean, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.start_bc_claim_attempt(text, boolean, jsonb) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.complete_bc_claim(uuid, uuid, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.complete_bc_claim(uuid, uuid, jsonb) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.record_bc_claim_failure(uuid, uuid, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.record_bc_claim_failure(uuid, uuid, jsonb) TO service_role;

--- a/supabase/migrations/20260520072138_bc_payload_status_gate_and_search_path.sql
+++ b/supabase/migrations/20260520072138_bc_payload_status_gate_and_search_path.sql
@@ -1,0 +1,191 @@
+-- Corrective migration for PR #120 review: search_path baked in + status gate + grants.
+CREATE OR REPLACE FUNCTION public.get_bc_claim_payload(p_claim_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_already_submitted_id UUID;
+  v_payment_mode_name    TEXT;
+  v_status               public.claim_status;
+  v_result               JSONB;
+BEGIN
+  SELECT c.bc_claim_details_id, mpm.name, c.status
+    INTO v_already_submitted_id, v_payment_mode_name, v_status
+  FROM public.claims c
+  JOIN public.master_payment_modes mpm ON mpm.id = c.payment_mode_id
+  WHERE c.id = p_claim_id AND c.is_active = true;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'CLAIM_NOT_FOUND: %', p_claim_id USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_already_submitted_id IS NOT NULL THEN
+    RAISE EXCEPTION 'ALREADY_SUBMITTED: %', v_already_submitted_id USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_status <> 'HOD approved - Awaiting finance approval'::public.claim_status THEN
+    RAISE EXCEPTION 'INVALID_CLAIM_STATE: % is %', p_claim_id, v_status
+      USING ERRCODE = 'P0005';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'claim_id',                     c.id,
+    'payment_mode_name',            v_payment_mode_name,
+    'submission_type',              c.submission_type,
+    'employee_id',                  c.employee_id,
+    'on_behalf_employee_code',      c.on_behalf_employee_code,
+    'employee_name',
+      CASE WHEN c.submission_type = 'On Behalf'::public.claim_submission_type
+           THEN COALESCE(onbehalf.full_name, '')
+           ELSE COALESCE(submitter.full_name, '')
+      END,
+    'program_code',                 ppm.program_code,
+    'sub_product_code',             spm.sub_product_code,
+    'responsible_department_code',  drm.responsible_department_code,
+    'beneficiary_department_code',  drm.beneficiary_department_code,
+    'region_code',                  elm.region_code,
+    'bill_no',                      ed.bill_no,
+    'transaction_date',             ed.transaction_date,
+    'purpose',                      ed.purpose,
+    'receipt_file_path',            ed.receipt_file_path,
+    'bank_statement_file_path',     ed.bank_statement_file_path,
+    'bc_code',                      ecm.bc_code,
+    'basic_amount',                 ed.basic_amount,
+    'total_amount',                 ed.total_amount,
+    'foreign_basic_amount',         COALESCE(ed.foreign_basic_amount, 0),
+    'foreign_total_amount',         COALESCE(ed.foreign_total_amount, 0)
+  )
+  INTO v_result
+  FROM public.claims c
+  JOIN public.expense_details ed                    ON ed.claim_id = c.id AND ed.is_active = true
+  JOIN public.users submitter                       ON submitter.id = c.submitted_by
+  LEFT JOIN public.users onbehalf                   ON onbehalf.id = c.on_behalf_of_id
+  JOIN public.expense_category_bc_mappings ecm      ON ecm.expense_category_id = ed.expense_category_id AND ecm.is_active = true
+  JOIN LATERAL (
+    SELECT program_code FROM public.master_program_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) ppm ON true
+  JOIN LATERAL (
+    SELECT sub_product_code FROM public.master_sub_product_mappings
+    WHERE product_id = ed.product_id AND is_active = true LIMIT 1
+  ) spm ON true
+  JOIN LATERAL (
+    SELECT responsible_department_code, beneficiary_department_code
+    FROM public.master_department_responsible_mappings
+    WHERE department_id = c.department_id AND is_active = true LIMIT 1
+  ) drm ON true
+  JOIN LATERAL (
+    SELECT region_code FROM public.master_expense_location_mappings
+    WHERE location_id = ed.location_id AND is_active = true LIMIT 1
+  ) elm ON true
+  WHERE c.id = p_claim_id;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'MISSING_MAPPING: one or more required mappings missing for claim %', p_claim_id
+      USING ERRCODE = 'P0003';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.start_bc_claim_attempt(
+  p_claim_id          TEXT,
+  p_is_vendor_payment BOOLEAN,
+  p_payload_json      JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_bc_details_id UUID;
+BEGIN
+  INSERT INTO public.bc_claim_details
+    (claim_id, is_vendor_payment, bc_status, bc_payload_json, bc_response_json)
+  VALUES
+    (p_claim_id, p_is_vendor_payment, 'submitting', p_payload_json, NULL)
+  RETURNING id INTO v_bc_details_id;
+
+  RETURN v_bc_details_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_bc_claim(
+  p_bc_details_id     UUID,
+  p_actor_user_id     UUID,
+  p_response_json     JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claim_id TEXT;
+BEGIN
+  UPDATE public.bc_claim_details
+  SET    bc_status        = 'success',
+         bc_response_json = p_response_json
+  WHERE  id        = p_bc_details_id
+    AND  bc_status = 'submitting'
+  RETURNING claim_id INTO v_claim_id;
+
+  IF v_claim_id IS NULL THEN
+    RAISE EXCEPTION 'BC_DETAILS_NOT_IN_FLIGHT: %', p_bc_details_id USING ERRCODE = 'P0004';
+  END IF;
+
+  UPDATE public.claims
+  SET    bc_claim_details_id = p_bc_details_id,
+         status              = 'Finance Approved - Payment under process',
+         updated_at          = now()
+  WHERE  id = v_claim_id;
+
+  INSERT INTO public.claim_audit_logs (claim_id, actor_id, action_type, remarks)
+  VALUES (v_claim_id, p_actor_user_id, 'BC_SUBMITTED',
+          'bc_claim_details_id: ' || p_bc_details_id::text);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_bc_claim_failure(
+  p_bc_details_id     UUID,
+  p_actor_user_id     UUID,
+  p_response_json     JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claim_id TEXT;
+BEGIN
+  UPDATE public.bc_claim_details
+  SET    bc_status        = 'failed',
+         bc_response_json = p_response_json
+  WHERE  id        = p_bc_details_id
+    AND  bc_status = 'submitting'
+  RETURNING claim_id INTO v_claim_id;
+
+  IF v_claim_id IS NULL THEN
+    RAISE EXCEPTION 'BC_DETAILS_NOT_IN_FLIGHT: %', p_bc_details_id USING ERRCODE = 'P0004';
+  END IF;
+
+  INSERT INTO public.claim_audit_logs (claim_id, actor_id, action_type, remarks)
+  VALUES (v_claim_id, p_actor_user_id, 'BC_SUBMISSION_FAILED',
+          'bc_claim_details_id: ' || p_bc_details_id::text);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_bc_claim_payload(TEXT)               FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.start_bc_claim_attempt(TEXT, BOOLEAN, JSONB) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.complete_bc_claim(UUID, UUID, JSONB)     FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.record_bc_claim_failure(UUID, UUID, JSONB) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.get_bc_claim_payload(TEXT)               TO service_role;
+GRANT EXECUTE ON FUNCTION public.start_bc_claim_attempt(TEXT, BOOLEAN, JSONB) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_bc_claim(UUID, UUID, JSONB)     TO service_role;
+GRANT EXECUTE ON FUNCTION public.record_bc_claim_failure(UUID, UUID, JSONB) TO service_role;;

--- a/supabase/migrations/20260520120000_fix_bc_claim_details_view_join.sql
+++ b/supabase/migrations/20260520120000_fix_bc_claim_details_view_join.sql
@@ -1,0 +1,245 @@
+-- Fix dashboard view fan-out caused by bc_claim_details JOIN.
+--
+-- Both views joined bc_claim_details on `bcd.claim_id = c.id`, but the
+-- bc_claim_details_one_active_per_claim unique index is PARTIAL
+-- (only unique when bc_status IN ('submitting', 'success')). A claim with
+-- multiple failed payment attempts therefore has multiple bc_claim_details rows,
+-- causing the view to fan out and return duplicate rows per claim.
+--
+-- Fix: join on `bcd.id = c.bc_claim_details_id` — a 1:1 primary-key join using
+-- the FK column already present on claims that points to the canonical row.
+
+drop view if exists public.vw_admin_claims_dashboard;
+
+create view public.vw_admin_claims_dashboard
+with (security_invoker = 'on') as
+select
+  c.id as claim_id,
+  coalesce(
+    nullif(trim(both from u.full_name), ''),
+    nullif(trim(both from split_part(u.email, '@', 1)), ''),
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    'N/A'
+  ) as employee_name,
+  coalesce(
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_employee_code), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    nullif(trim(both from u.email), ''),
+    'N/A'
+  ) as employee_id,
+  c.employee_id as claim_employee_id_raw,
+  c.on_behalf_employee_code as on_behalf_employee_code_raw,
+  nullif(trim(both from u.full_name), '') as submitter_name_raw,
+  nullif(trim(both from beneficiary.full_name), '') as beneficiary_name_raw,
+  coalesce(nullif(trim(both from md.name), ''), 'Unknown Department') as department_name,
+  coalesce(
+    nullif(trim(both from mpm.name), ''),
+    case
+      when c.detail_type = 'advance' then 'Advance'
+      when c.detail_type = 'expense' then 'Expense'
+      else 'Unknown'
+    end
+  ) as type_of_claim,
+  coalesce(ed.total_amount, ad.total_amount, 0::numeric)::numeric(14,2) as amount,
+  c.status,
+  coalesce(c.submitted_at, c.created_at) as submitted_on,
+  coalesce(
+    c.hod_action_at,
+    case
+      when c.status = 'HOD approved - Awaiting finance approval'::public.claim_status then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as hod_action_date,
+  coalesce(
+    c.finance_action_at,
+    case
+      when c.status = any(array[
+        'Finance Approved - Payment under process'::public.claim_status,
+        'Payment Done - Closed'::public.claim_status
+      ]) then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is not null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as finance_action_date,
+  coalesce(ed.location_id, ad.location_id) as location_id,
+  coalesce(ed.product_id, ad.product_id) as product_id,
+  ed.expense_category_id,
+  c.submitted_by,
+  c.on_behalf_of_id,
+  c.on_behalf_email,
+  c.assigned_l1_approver_id,
+  c.assigned_l2_approver_id,
+  c.department_id,
+  c.payment_mode_id,
+  c.detail_type,
+  c.submission_type,
+  c.is_active,
+  c.created_at,
+  c.updated_at,
+  c.deleted_by,
+  c.deleted_at,
+  nullif(trim(both from deleted_by_user.full_name), '') as deleted_by_name,
+  case
+    when c.deleted_by is null then null::text
+    when exists (
+      select 1
+      from public.admins a
+      where a.user_id = c.deleted_by
+    ) then 'admin'
+    when exists (
+      select 1
+      from public.master_finance_approvers f
+      where f.user_id = c.deleted_by
+        and f.is_active = true
+    ) then 'finance'
+    else 'employee'
+  end as deleted_by_role,
+  u.email as submitter_email,
+  hod.email as hod_email,
+  finance.email as finance_email,
+  case
+    when nullif(trim(both from u.full_name), '') is not null and nullif(trim(both from u.email), '') is not null then trim(both from u.full_name) || ' (' || trim(both from u.email) || ')'
+    when nullif(trim(both from u.full_name), '') is not null then trim(both from u.full_name)
+    when nullif(trim(both from u.email), '') is not null then trim(both from u.email)
+    else c.employee_id
+  end as submitter_label,
+  case
+    when c.detail_type = 'expense' then coalesce(nullif(trim(both from mec_name.name), ''), 'Uncategorized')
+    else 'Advance'
+  end as category_name,
+  coalesce(ed.purpose, ad.purpose) as purpose,
+  ed.receipt_file_path,
+  ed.bank_statement_file_path,
+  ad.supporting_document_path,
+  c.bc_claim_details_id,
+  coalesce(bcd.is_vendor_payment, false) as is_vendor_payment
+from public.claims c
+left join public.users u on u.id = c.submitted_by
+left join public.users beneficiary on beneficiary.id = c.on_behalf_of_id
+left join public.users hod on hod.id = c.assigned_l1_approver_id
+left join public.users finance on finance.id = c.assigned_l2_approver_id
+left join public.users deleted_by_user on deleted_by_user.id = c.deleted_by
+left join public.master_departments md on md.id = c.department_id
+left join public.master_payment_modes mpm on mpm.id = c.payment_mode_id
+left join public.expense_details ed on ed.claim_id = c.id
+left join public.master_expense_categories mec_name on mec_name.id = ed.expense_category_id
+left join public.advance_details ad on ad.claim_id = c.id
+left join public.bc_claim_details bcd on bcd.id = c.bc_claim_details_id;
+
+
+drop view if exists public.vw_enterprise_claims_dashboard;
+
+create view public.vw_enterprise_claims_dashboard
+with (security_invoker = 'on') as
+select
+  c.id as claim_id,
+  coalesce(
+    nullif(trim(both from u.full_name), ''),
+    nullif(trim(both from split_part(u.email, '@', 1)), ''),
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    'N/A'
+  ) as employee_name,
+  coalesce(
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_employee_code), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    nullif(trim(both from u.email), ''),
+    'N/A'
+  ) as employee_id,
+  c.employee_id as claim_employee_id_raw,
+  c.on_behalf_employee_code as on_behalf_employee_code_raw,
+  nullif(trim(both from u.full_name), '') as submitter_name_raw,
+  nullif(trim(both from beneficiary.full_name), '') as beneficiary_name_raw,
+  coalesce(nullif(trim(both from md.name), ''), 'Unknown Department') as department_name,
+  coalesce(
+    nullif(trim(both from mpm.name), ''),
+    case
+      when c.detail_type = 'advance' then 'Advance'
+      when c.detail_type = 'expense' then 'Expense'
+      else 'Unknown'
+    end
+  ) as type_of_claim,
+  coalesce(ed.total_amount, ad.total_amount, 0::numeric)::numeric(14,2) as amount,
+  c.status,
+  coalesce(c.submitted_at, c.created_at) as submitted_on,
+  coalesce(
+    c.hod_action_at,
+    case
+      when c.status = 'HOD approved - Awaiting finance approval'::public.claim_status then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as hod_action_date,
+  coalesce(
+    c.finance_action_at,
+    case
+      when c.status = any(array[
+        'Finance Approved - Payment under process'::public.claim_status,
+        'Payment Done - Closed'::public.claim_status
+      ]) then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is not null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as finance_action_date,
+  coalesce(ed.location_id, ad.location_id) as location_id,
+  coalesce(ed.product_id, ad.product_id) as product_id,
+  ed.expense_category_id,
+  c.submitted_by,
+  c.on_behalf_of_id,
+  c.on_behalf_email,
+  c.assigned_l1_approver_id,
+  c.assigned_l2_approver_id,
+  c.department_id,
+  c.payment_mode_id,
+  c.detail_type,
+  c.submission_type,
+  c.is_active,
+  c.created_at,
+  c.updated_at,
+  u.email as submitter_email,
+  hod.email as hod_email,
+  finance.email as finance_email,
+  case
+    when nullif(trim(both from u.full_name), '') is not null and nullif(trim(both from u.email), '') is not null then trim(both from u.full_name) || ' (' || trim(both from u.email) || ')'
+    when nullif(trim(both from u.full_name), '') is not null then trim(both from u.full_name)
+    when nullif(trim(both from u.email), '') is not null then trim(both from u.email)
+    else c.employee_id
+  end as submitter_label,
+  case
+    when c.detail_type = 'expense' then coalesce(nullif(trim(both from mec_name.name), ''), 'Uncategorized')
+    else 'Advance'
+  end as category_name,
+  coalesce(ed.purpose, ad.purpose) as purpose,
+  ed.receipt_file_path,
+  ed.bank_statement_file_path,
+  ad.supporting_document_path,
+  c.bc_claim_details_id,
+  coalesce(bcd.is_vendor_payment, false) as is_vendor_payment
+from public.claims c
+left join public.users u on u.id = c.submitted_by
+left join public.users beneficiary on beneficiary.id = c.on_behalf_of_id
+left join public.users hod on hod.id = c.assigned_l1_approver_id
+left join public.users finance on finance.id = c.assigned_l2_approver_id
+left join public.master_departments md on md.id = c.department_id
+left join public.master_payment_modes mpm on mpm.id = c.payment_mode_id
+left join public.expense_details ed on ed.claim_id = c.id and ed.is_active = true
+left join public.master_expense_categories mec_name on mec_name.id = ed.expense_category_id
+left join public.advance_details ad on ad.claim_id = c.id and ad.is_active = true
+left join public.bc_claim_details bcd on bcd.id = c.bc_claim_details_id
+where c.is_active = true;

--- a/supabase/rollbacks/20260520120000_fix_bc_claim_details_view_join_rollback.sql
+++ b/supabase/rollbacks/20260520120000_fix_bc_claim_details_view_join_rollback.sql
@@ -1,0 +1,243 @@
+-- Rollback: restore bc_claim_details JOIN to bcd.claim_id = c.id
+-- (reverts 20260520120000_fix_bc_claim_details_view_join.sql)
+
+drop view if exists public.vw_admin_claims_dashboard;
+
+create view public.vw_admin_claims_dashboard
+with (security_invoker = 'on') as
+select
+  c.id as claim_id,
+  coalesce(
+    nullif(trim(both from u.full_name), ''),
+    nullif(trim(both from split_part(u.email, '@', 1)), ''),
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    'N/A'
+  ) as employee_name,
+  coalesce(
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_employee_code), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    nullif(trim(both from u.email), ''),
+    'N/A'
+  ) as employee_id,
+  c.employee_id as claim_employee_id_raw,
+  c.on_behalf_employee_code as on_behalf_employee_code_raw,
+  nullif(trim(both from u.full_name), '') as submitter_name_raw,
+  nullif(trim(both from beneficiary.full_name), '') as beneficiary_name_raw,
+  coalesce(nullif(trim(both from md.name), ''), 'Unknown Department') as department_name,
+  coalesce(
+    nullif(trim(both from mpm.name), ''),
+    case
+      when c.detail_type = 'advance' then 'Advance'
+      when c.detail_type = 'expense' then 'Expense'
+      else 'Unknown'
+    end
+  ) as type_of_claim,
+  coalesce(
+    ed.approved_amount,
+    ed.requested_total_amount,
+    ad.approved_amount,
+    ad.requested_total_amount,
+    0
+  )::numeric(14,2) as amount,
+  c.status,
+  coalesce(c.submitted_at, c.created_at) as submitted_on,
+  coalesce(
+    c.hod_action_at,
+    case
+      when c.status = 'HOD approved - Awaiting finance approval'::public.claim_status then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as hod_action_date,
+  coalesce(
+    c.finance_action_at,
+    case
+      when c.status = any(array[
+        'Finance Approved - Payment under process'::public.claim_status,
+        'Payment Done - Closed'::public.claim_status
+      ]) then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is not null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as finance_action_date,
+  coalesce(ed.location_id, ad.location_id) as location_id,
+  coalesce(ed.product_id, ad.product_id) as product_id,
+  ed.expense_category_id,
+  c.submitted_by,
+  c.on_behalf_of_id,
+  c.on_behalf_email,
+  c.assigned_l1_approver_id,
+  c.assigned_l2_approver_id,
+  c.department_id,
+  c.payment_mode_id,
+  c.detail_type,
+  c.submission_type,
+  c.is_active,
+  c.created_at,
+  c.updated_at,
+  c.deleted_by,
+  c.deleted_at,
+  nullif(trim(both from deleted_by_user.full_name), '') as deleted_by_name,
+  case
+    when c.deleted_by is null then null::text
+    when exists (
+      select 1
+      from public.admins a
+      where a.user_id = c.deleted_by
+    ) then 'admin'
+    when exists (
+      select 1
+      from public.master_finance_approvers f
+      where f.user_id = c.deleted_by
+        and f.is_active = true
+    ) then 'finance'
+    else 'employee'
+  end as deleted_by_role,
+  u.email as submitter_email,
+  hod.email as hod_email,
+  finance.email as finance_email,
+  case
+    when nullif(trim(both from u.full_name), '') is not null and nullif(trim(both from u.email), '') is not null then trim(both from u.full_name) || ' (' || trim(both from u.email) || ')'
+    when nullif(trim(both from u.full_name), '') is not null then trim(both from u.full_name)
+    when nullif(trim(both from u.email), '') is not null then trim(both from u.email)
+    else c.employee_id
+  end as submitter_label,
+  case
+    when c.detail_type = 'expense' then coalesce(nullif(trim(both from mec_name.name), ''), 'Uncategorized')
+    else 'Advance'
+  end as category_name,
+  coalesce(ed.purpose, ad.purpose) as purpose,
+  ed.receipt_file_path,
+  ed.bank_statement_file_path,
+  ad.supporting_document_path,
+  c.bc_claim_details_id,
+  coalesce(bcd.is_vendor_payment, false) as is_vendor_payment
+from public.claims c
+left join public.users u on u.id = c.submitted_by
+left join public.users beneficiary on beneficiary.id = c.on_behalf_of_id
+left join public.users hod on hod.id = c.assigned_l1_approver_id
+left join public.users finance on finance.id = c.assigned_l2_approver_id
+left join public.users deleted_by_user on deleted_by_user.id = c.deleted_by
+left join public.master_departments md on md.id = c.department_id
+left join public.master_payment_modes mpm on mpm.id = c.payment_mode_id
+left join public.expense_details ed on ed.claim_id = c.id
+left join public.master_expense_categories mec_name on mec_name.id = ed.expense_category_id
+left join public.advance_details ad on ad.claim_id = c.id
+left join public.bc_claim_details bcd on bcd.claim_id = c.id;
+
+
+drop view if exists public.vw_enterprise_claims_dashboard;
+
+create view public.vw_enterprise_claims_dashboard
+with (security_invoker = 'on') as
+select
+  c.id as claim_id,
+  coalesce(
+    nullif(trim(both from u.full_name), ''),
+    nullif(trim(both from split_part(u.email, '@', 1)), ''),
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    'N/A'
+  ) as employee_name,
+  coalesce(
+    nullif(trim(both from c.employee_id), ''),
+    nullif(trim(both from c.on_behalf_employee_code), ''),
+    nullif(trim(both from c.on_behalf_email), ''),
+    nullif(trim(both from u.email), ''),
+    'N/A'
+  ) as employee_id,
+  c.employee_id as claim_employee_id_raw,
+  c.on_behalf_employee_code as on_behalf_employee_code_raw,
+  nullif(trim(both from u.full_name), '') as submitter_name_raw,
+  nullif(trim(both from beneficiary.full_name), '') as beneficiary_name_raw,
+  coalesce(nullif(trim(both from md.name), ''), 'Unknown Department') as department_name,
+  coalesce(
+    nullif(trim(both from mpm.name), ''),
+    case
+      when c.detail_type = 'advance' then 'Advance'
+      when c.detail_type = 'expense' then 'Expense'
+      else 'Unknown'
+    end
+  ) as type_of_claim,
+  coalesce(ed.total_amount, ad.total_amount, 0::numeric)::numeric(14,2) as amount,
+  c.status,
+  coalesce(c.submitted_at, c.created_at) as submitted_on,
+  coalesce(
+    c.hod_action_at,
+    case
+      when c.status = 'HOD approved - Awaiting finance approval'::public.claim_status then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as hod_action_date,
+  coalesce(
+    c.finance_action_at,
+    case
+      when c.status = any(array[
+        'Finance Approved - Payment under process'::public.claim_status,
+        'Payment Done - Closed'::public.claim_status
+      ]) then c.updated_at
+      when c.status = any(array[
+        'Rejected - Resubmission Not Allowed'::public.claim_status,
+        'Rejected - Resubmission Allowed'::public.claim_status
+      ]) and c.assigned_l2_approver_id is not null then c.updated_at
+      else null::timestamp with time zone
+    end
+  ) as finance_action_date,
+  coalesce(ed.location_id, ad.location_id) as location_id,
+  coalesce(ed.product_id, ad.product_id) as product_id,
+  ed.expense_category_id,
+  c.submitted_by,
+  c.on_behalf_of_id,
+  c.on_behalf_email,
+  c.assigned_l1_approver_id,
+  c.assigned_l2_approver_id,
+  c.department_id,
+  c.payment_mode_id,
+  c.detail_type,
+  c.submission_type,
+  c.is_active,
+  c.created_at,
+  c.updated_at,
+  u.email as submitter_email,
+  hod.email as hod_email,
+  finance.email as finance_email,
+  case
+    when nullif(trim(both from u.full_name), '') is not null and nullif(trim(both from u.email), '') is not null then trim(both from u.full_name) || ' (' || trim(both from u.email) || ')'
+    when nullif(trim(both from u.full_name), '') is not null then trim(both from u.full_name)
+    when nullif(trim(both from u.email), '') is not null then trim(both from u.email)
+    else c.employee_id
+  end as submitter_label,
+  case
+    when c.detail_type = 'expense' then coalesce(nullif(trim(both from mec_name.name), ''), 'Uncategorized')
+    else 'Advance'
+  end as category_name,
+  coalesce(ed.purpose, ad.purpose) as purpose,
+  ed.receipt_file_path,
+  ed.bank_statement_file_path,
+  ad.supporting_document_path,
+  c.bc_claim_details_id,
+  coalesce(bcd.is_vendor_payment, false) as is_vendor_payment
+from public.claims c
+left join public.users u on u.id = c.submitted_by
+left join public.users beneficiary on beneficiary.id = c.on_behalf_of_id
+left join public.users hod on hod.id = c.assigned_l1_approver_id
+left join public.users finance on finance.id = c.assigned_l2_approver_id
+left join public.master_departments md on md.id = c.department_id
+left join public.master_payment_modes mpm on mpm.id = c.payment_mode_id
+left join public.expense_details ed on ed.claim_id = c.id and ed.is_active = true
+left join public.master_expense_categories mec_name on mec_name.id = ed.expense_category_id
+left join public.advance_details ad on ad.claim_id = c.id and ad.is_active = true
+left join public.bc_claim_details bcd on bcd.claim_id = c.id
+where c.is_active = true;


### PR DESCRIPTION
## Summary

Three logically distinct changes, bundled because `fixDashboard` was branched off the `bc_int` line which is ahead of `development`.

### 1. Dashboard view fan-out fix (the headline)
`supabase/migrations/20260520120000_fix_bc_claim_details_view_join.sql` repoints the `bc_claim_details` JOIN in `vw_admin_claims_dashboard` and `vw_enterprise_claims_dashboard` from `bcd.claim_id = c.id` to `bcd.id = c.bc_claim_details_id`.

Why: the `bc_claim_details_one_active_per_claim` unique index is **partial** (only unique when `bc_status IN ('submitting','success')`), so a claim with multiple failed payment attempts has multiple `bc_claim_details` rows. The previous JOIN caused row fan-out (duplicate dashboard rows per claim). Joining on the FK column `c.bc_claim_details_id` is a guaranteed 1:1 PK lookup against the canonical row.

Rollback included: `supabase/rollbacks/20260520120000_fix_bc_claim_details_view_join_rollback.sql`.

### 2. Delete-claim modal — portal rendering
`src/modules/claims/ui/delete-claim-button.tsx` now renders the confirmation modal through `createPortal(modal, document.body)` instead of inline, and raises overlay z-index from `z-50` → `z-[260]`. Fixes stacking/z-index issues when the button sits inside a card or transformed parent. Sits cleanly above existing modal layers (sheet 120, PolicyGate 180, dialog 220) and below sonner toasts (default 9999999).

### 3. Brings bc_int migration train into development
The remaining migrations in the diff were authored on the `bc_int` PR line and merged to `main` via PR #129. They are listed here so reviewers don't think they are part of this PR's new work:

- `20260519140000_bc_payload_add_amount_fields.sql`
- `20260520000000_claim_submission_type_enum.sql` (claims.submission_type text → enum; drops/recreates both dashboard views as part of the dependency cycle)
- `20260520010000_restore_security_invoker_on_enum_views.sql`
- `20260520020000_bc_functions_set_search_path.sql`
- `20260520030000_bc_functions_revoke_anon_execute.sql`
- `20260520072138_bc_payload_status_gate_and_search_path.sql` (security hardening + INVALID_CLAIM_STATE gate, already deployed to NxtClaimTest)

These are required dependencies of the dashboard view fix because the recreated views reference the new enum column and amount fields.

## Verification

- `bcd.id = c.bc_claim_details_id` is a PK join — fan-out impossible by construction.
- No other views or materialized views depend on `vw_admin_claims_dashboard` / `vw_enterprise_claims_dashboard`. The only consumer is the function `public.get_dashboard_analytics_payload`, which references the views by name at execution time (no pg_depend hard link). `DROP VIEW IF EXISTS` (no CASCADE) is safe.
- z-[260] sits above all internal modal layers and below sonner toasts.

## Test plan

- [ ] Confirm dashboard shows one row per claim for a claim that has multiple failed BC payment attempts (previously fanned out).
- [ ] Confirm enterprise dashboard is unaffected for claims with zero or one `bc_claim_details` rows.
- [ ] Confirm `get_dashboard_analytics_payload` continues to return correct aggregates after the view recreate.
- [ ] Confirm delete-claim modal renders above all modal/dialog layers and toasts still appear above it.
- [ ] Run all integration tests (`bc-claim-rpc`, `bc-rpc-anon-lockdown`, `bc-edge-deployment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)